### PR TITLE
fix: AccountInfo Provider should handle case where account doesn't exist

### DIFF
--- a/packages/mina-graphql/src/Providers/AccountInfo/AccountInfoProvider.ts
+++ b/packages/mina-graphql/src/Providers/AccountInfo/AccountInfoProvider.ts
@@ -65,8 +65,22 @@ export class AccountInfoGraphQLProvider implements AccountInfoProvider {
       }
       return data.account
     } catch (error: unknown) {
-      console.error('Error in getAccountInfo:', error)
-      throw error
+      // this can fail if the account doesn't exist yet on the chain & if the node is not available
+      // perform health check to see if the node is available
+      const healthCheckResponse = await this.healthCheck()
+      if (!healthCheckResponse.ok) {
+        throw new Error('Node is not available')
+      }
+      // if the node is available, then the account doesn't exist yet
+      // return an empty account
+      console.log('Error in getAccountInfo, account does not exist yet!')
+      return {
+        balance: { total: 0 },
+        nonce: 0,
+        inferredNonce: 0,
+        delegate: '',
+        publicKey: args.publicKey
+      }
     }
   }
 }

--- a/packages/mina-graphql/test/provider.test.ts
+++ b/packages/mina-graphql/test/provider.test.ts
@@ -11,6 +11,8 @@ import { MinaProvider } from '../src'
 
 const nodeUrl = 'https://proxy.devnet.minaexplorer.com/'
 const explorerUrl = 'https://devnet.graphql.minaexplorer.com'
+const nodeUrlMainnet = 'https://proxy.minaexplorer.com/'
+const explorerUrlMainnet = 'https://graphql.minaexplorer.com'
 
 describe('Provider', () => {
   let provider: MinaProvider
@@ -30,6 +32,21 @@ describe('Provider', () => {
     expect(response.inferredNonce).toBeDefined()
     expect(response.delegate).toBeDefined()
     expect(response.publicKey).toBeDefined()
+  })
+  test('getAccountInfo (mainnet)', async () => {
+    const args: AccountInfoArgs = {
+      publicKey: 'B62qkAqbeE4h1M5hop288jtVYxK1MsHVMMcBpaWo8qdsAztgXaHH1xq' // this must be a public key that doesn't exist yet on mainnet
+    }
+    const mainnetProvider = new MinaProvider(nodeUrlMainnet, explorerUrlMainnet)
+    const response = await mainnetProvider.getAccountInfo(args)
+    console.log('Response:', response)
+
+    // expect the account to not exist yet
+    expect(response.balance).toHaveProperty('total', 0)
+    expect(response.nonce).toBe(0)
+    expect(response.inferredNonce).toBe(0)
+    expect(response.delegate).toBe('')
+    expect(response.publicKey).toBe(args.publicKey)
   })
   test('getTransactions', async () => {
     const args: TransactionsByAddressesArgs = {


### PR DESCRIPTION
## Describe changes
AccountInfo Provider should handle case where the account doesn't exist on the network and return an `AccountInfo` object describing an empty account.
