### PR TITLE
fix(vault tests): add ensure account

### DIFF
--- a/packages/vault/test/account/accountStore.test.ts
+++ b/packages/vault/test/account/accountStore.test.ts
@@ -60,12 +60,16 @@ describe('AccountStore', () => {
     const { result } = renderHook(() => useVault())
     const accountInfo = mockAccountInfo
     act(() => {
+      // adding an ensureAccount call here to ensure the account is created
+      // this fixes `TypeError: Cannot read properties of undefined`
+      result.current.ensureAccount(network, address)
       result.current.setAccountInfo(network, address, accountInfo)
       finalAccountInfo = result.current.getAccountInfo(
         network,
         address
       ).accountInfo
     })
+    console.log('finalAccountInfo', finalAccountInfo)
     expect(finalAccountInfo).toEqual(accountInfo)
   })
 


### PR DESCRIPTION
## Describe changes
Fixing tests that are failing.

Previously the `@palladxyz/vault` test for `Accounts` was failing with the following error:
```bash
TypeError: Cannot read properties of undefined (reading 'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb')
 ❯ src/account/accountStore.ts:35:36
     33|       produce((state) => {
     34|         state.accounts[network][address] = {
     35|           ...state.accounts[network][address],
       |                                    ^
     36|           accountInfo
     37|         }
```

A quick fix using `ensureAccount` solves this. However further discussion is needed to define whether this is the best solution.