### PR TITLE
fix(transaction tab): add total & usd value 💰

### DIFF
--- a/packages/features/src/common/types.ts
+++ b/packages/features/src/common/types.ts
@@ -22,6 +22,7 @@ export type StructurizedTransaction = Mina.TransactionBody & {
   time: string
   minaAmount: number
   minaFee: number
+  txTotalMinaAmount: number
 }
 
 type StakingAccount = {

--- a/packages/features/src/transactions/components/TxTile.tsx
+++ b/packages/features/src/transactions/components/TxTile.tsx
@@ -10,25 +10,22 @@ interface TxTileProps {
   tx: StructurizedTransaction
 }
 
+const fiatTxValue = (amount, fiatValue) => {
+  if (!amount || !fiatValue) return 0
+  return Number(amount) * fiatValue
+}
+
+const getTransactionLabel = (tx) => {
+  if (tx.kind === TxKind.STAKE_DELEGATION) return 'Delegation'
+  if (tx.from === tx.to && tx.kind === TxKind.PAYMENT) return 'Sent to Self'
+  return tx.side === TxSide.INCOMING ? 'Received' : 'Sent'
+}
+
 export const TxTile = ({ tx }: TxTileProps) => {
   const navigate = useNavigate()
   const { data: fiatPriceData } = useFiatPrice()
-  const rawFiatPrice = fiatPriceData?.['mina-protocol']?.usd || 0
-  const fiatTxValue = (tx: StructurizedTransaction, fiatValue: number) => {
-    if (!tx.txTotalMinaAmount) return
-    if (!fiatValue) return
-    return Number(tx.txTotalMinaAmount) * fiatValue
-  }
+  const rawFiatPrice = fiatPriceData?.['mina-protocol']?.usd ?? 0
 
-  const getTransactionLabel = (tx: StructurizedTransaction) => {
-    if (tx.kind === TxKind.STAKE_DELEGATION) {
-      return 'Delegation'
-    }
-    if (tx.from === tx.to && tx.kind === TxKind.PAYMENT) {
-      return 'Sent to Self'
-    }
-    return tx.side === TxSide.INCOMING ? 'Received' : 'Sent'
-  }
   return (
     <div
       key={tx.hash}
@@ -48,7 +45,9 @@ export const TxTile = ({ tx }: TxTileProps) => {
           <MinaIcon stroke="8" size="18" />
         </div>
         <div className="flex items-center text-xs">
-          <span>{fiatTxValue(tx, rawFiatPrice).toFixed(3)}</span>
+          <span>
+            {fiatTxValue(tx.txTotalMinaAmount, rawFiatPrice).toFixed(3)}
+          </span>
           <span className="ml-1">USD</span>
         </div>
       </div>

--- a/packages/features/src/transactions/components/TxTile.tsx
+++ b/packages/features/src/transactions/components/TxTile.tsx
@@ -1,3 +1,4 @@
+import { useFiatPrice } from '@palladxyz/offchain-data'
 import { useNavigate } from 'react-router-dom'
 
 import { MinaIcon } from '@/common/components/MinaIcon'
@@ -11,6 +12,14 @@ interface TxTileProps {
 
 export const TxTile = ({ tx }: TxTileProps) => {
   const navigate = useNavigate()
+  const { data: fiatPriceData } = useFiatPrice()
+  const rawFiatPrice = fiatPriceData?.['mina-protocol']?.usd || 0
+  const fiatTxValue = (tx: StructurizedTransaction, fiatValue: number) => {
+    if (!tx.txTotalMinaAmount) return
+    if (!fiatValue) return
+    return Number(tx.txTotalMinaAmount) * fiatValue
+  }
+
   const getTransactionLabel = (tx: StructurizedTransaction) => {
     if (tx.kind === TxKind.STAKE_DELEGATION) {
       return 'Delegation'
@@ -35,13 +44,12 @@ export const TxTile = ({ tx }: TxTileProps) => {
       </div>
       <div className="flex flex-col items-end gap-2">
         <div className="flex items-center font-semibold">
-          <span>{tx.minaAmount}</span>
+          <span>{tx.txTotalMinaAmount}</span>
           <MinaIcon stroke="8" size="18" />
         </div>
         <div className="flex items-center text-xs">
-          <span>{tx.minaFee}</span>
-          <MinaIcon stroke="8" size="12" />
-          <span className="ml-1">Fee</span>
+          <span>{fiatTxValue(tx, rawFiatPrice).toFixed(3)}</span>
+          <span className="ml-1">USD</span>
         </div>
       </div>
     </div>

--- a/packages/features/src/transactions/utils/structurizeTransactions.ts
+++ b/packages/features/src/transactions/utils/structurizeTransactions.ts
@@ -21,6 +21,10 @@ export const structurizeTransaction = ({
   time: dayjs(tx.dateTime).format('HH:mm'),
   minaAmount: (Number(tx.amount) / 1_000_000_000).toFixed(3),
   minaFee: (Number(tx.fee) / 1_000_000_000).toFixed(3),
+  txTotalMinaAmount: (
+    (Number(tx.amount) + Number(tx.fee)) /
+    1_000_000_000
+  ).toFixed(3),
   side: tx.from === walletPublicKey ? TxSide.OUTGOING : TxSide.INCOMING
 })
 


### PR DESCRIPTION
## Describe changes
The `MinaIcon` wasn't looking great; information overload & clustered UI. The transaction tab has now been updated to have the leading value combined with the Mina amount and the transaction fee. Its value in USD is displayed below.

## Screenshots
It now looks like this:
<img width="395" alt="Screenshot 2023-12-21 at 18 55 41" src="https://github.com/palladians/pallad/assets/92999717/841630b3-4879-44a5-b78c-d71b2977e9cb">
