### PR TITLE
Feat: Web Provider RPC 🗣️

### DIFF
--- a/packages/key-management/src/chains/Mina/signingOperations.ts
+++ b/packages/key-management/src/chains/Mina/signingOperations.ts
@@ -26,10 +26,10 @@ export async function MinaSigningOperations<T extends MinaSignablePayload>(
     } else if (util.isZkAppTransaction(payload)) {
       return minaClient.signZkappCommand(payload.command, privateKey)
     } else {
-      throw new Error('Unsupported payload type.')
+      throw new Error(`Unsupported payload type of ${payload}.`)
     }
   } catch (err) {
     const errorMessage = errors.getRealErrorMsg(err) || 'Signing action failed.'
-    throw new Error(errorMessage)
+    throw new Error(`Error during Mina signing operations: ${errorMessage}`)
   }
 }

--- a/packages/web-provider/package.json
+++ b/packages/web-provider/package.json
@@ -23,6 +23,7 @@
     "@palladxyz/mina-graphql": "^0.0.1",
     "@palladxyz/multi-chain-core": "^0.0.1",
     "@palladxyz/vault": "^0.0.1",
+    "mina-signer": "^2.1.1",
     "vitest": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/web-provider/package.json
+++ b/packages/web-provider/package.json
@@ -22,11 +22,13 @@
     "@palladxyz/mina-core": "^0.0.1",
     "@palladxyz/mina-graphql": "^0.0.1",
     "@palladxyz/multi-chain-core": "^0.0.1",
-    "@palladxyz/vault": "^0.0.1"
+    "@palladxyz/vault": "^0.0.1",
+    "vitest": "^1.1.0"
   },
   "devDependencies": {
     "@palladxyz/common": "^1.0.0",
     "@testing-library/react": "^14.1.2",
+    "@types/chrome": "^0.0.254",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.10.5"
   }

--- a/packages/web-provider/src/Mina/MinaProvider.ts
+++ b/packages/web-provider/src/Mina/MinaProvider.ts
@@ -95,11 +95,31 @@ interface RequestArguments {
   method: RpcMethod
   params?: any[] | object
 }
-
 async function showUserPrompt(message: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const userResponse = window.confirm(message)
-    resolve(userResponse)
+    console.log('User Prompt Message:', message)
+    // TODO: figure out if we need to add "types": ["chrome"] to tsconfig.json?
+    // should add the following to the extension app next to background.js, manifest.json, etc.
+    // ├── prompt.html         // Your custom prompt HTML page
+    // ├── prompt.js           // JavaScript for prompt.html
+    // ├── prompt.css          // CSS for prompt.html
+    // Create a new window with your custom HTML page for the prompt
+    chrome.windows.create(
+      {
+        url: 'prompt.html',
+        type: 'popup'
+        // Add any additional window properties as needed
+      },
+      (newWindow) => {
+        // Handle the communication and response from the popup
+        chrome.runtime.onMessage.addListener(function listener(response) {
+          if (response.windowId === newWindow.id) {
+            resolve(response.userResponse)
+            chrome.runtime.onMessage.removeListener(listener)
+          }
+        })
+      }
+    )
   })
 }
 

--- a/packages/web-provider/src/Mina/MinaProvider.ts
+++ b/packages/web-provider/src/Mina/MinaProvider.ts
@@ -207,7 +207,12 @@ export class MinaProvider implements IMinaProvider {
       // should this emit an error event?
       throw new Error('User denied the request.')
     }
-    return await this.signer.request(args, this.chainId)
+    if (args.method === 'mina_accounts') {
+      // handle mina_accounts
+      return vaultService.getAddresses() as unknown as T
+    }
+    // For unsupported methods, throw an error with a descriptive message -- must error with correct standard error
+    throw new Error(`Method ${args.method} is not supported.`)
   }
 
   public exampleMethod(): (string | undefined)[] {

--- a/packages/web-provider/src/Mina/types.ts
+++ b/packages/web-provider/src/Mina/types.ts
@@ -17,7 +17,7 @@ export interface ProviderInfo {
 
 export interface RequestArguments {
   method: string
-  params?: unknown[] | object
+  params?: unknown[] | Record<string, unknown> | object | undefined
 }
 
 export type ProviderChainId = ProviderInfo['chainId']

--- a/packages/web-provider/src/Mina/vaultService.ts
+++ b/packages/web-provider/src/Mina/vaultService.ts
@@ -1,3 +1,4 @@
+import { ChainSignablePayload, GetPassphrase } from '@palladxyz/key-management'
 import { useVault } from '@palladxyz/vault'
 
 export class VaultService {
@@ -14,13 +15,21 @@ export class VaultService {
     return VaultService.instance
   }
 
-  getAddresses() {
+  getAccounts(): string[] {
     const store = useVault.getState()
     const credentials = store.credentials
     const addresses = Object.values(credentials).map(
       (cred) => cred?.credential?.address
     )
     return addresses
+  }
+
+  async sign(
+    signable: ChainSignablePayload,
+    getPassphrase: GetPassphrase
+  ): Promise<unknown> {
+    const store = useVault.getState()
+    return store.sign(signable, getPassphrase)
   }
 
   // Add other methods as needed

--- a/packages/web-provider/test/Mina/MinaProvider.test.ts
+++ b/packages/web-provider/test/Mina/MinaProvider.test.ts
@@ -10,6 +10,7 @@ import { KeyAgents, useVault } from '@palladxyz/vault'
 import { act, renderHook } from '@testing-library/react'
 
 import { MinaProvider } from '../../src/Mina'
+import { RequestArguments } from '../../src/Mina/types'
 
 const PREGENERATED_MNEMONIC = [
   'habit',
@@ -38,6 +39,12 @@ describe('WalletTest', () => {
   >
   let agentArgs: FromBip39MnemonicWordsProps
   const keyAgentName = 'test key agent'
+
+  beforeAll(() => {
+    // Mock window.confirm to always return true (or false)
+    global.window = Object.create(window)
+    window.confirm = () => true
+  })
 
   beforeEach(async () => {
     agentArgs = {
@@ -149,9 +156,26 @@ describe('WalletTest', () => {
     }
     const provider = await MinaProvider.init(opts)
 
+    // Define the request arguments for the 'mina_accounts' method
+    const requestArgs: RequestArguments = {
+      method: 'mina_accounts'
+    }
+
+    // Ensure the provider is defined
     expect(provider).toBeDefined()
-    const accountAddresses = provider.exampleMethod()
-    console.log('accountAddresses', accountAddresses)
-    expect(accountAddresses).toEqual(addresses)
+
+    // Call the request function with the appropriate arguments
+    provider
+      .request(requestArgs)
+      .then((accountAddresses) => {
+        console.log('accountAddresses', accountAddresses)
+
+        // Compare the received addresses with the expected ones
+        expect(accountAddresses).toEqual(addresses)
+      })
+      .catch((error) => {
+        // Handle any errors here
+        console.error('Error fetching account addresses:', error)
+      })
   })
 })

--- a/packages/web-provider/test/Mina/MinaProvider.test.ts
+++ b/packages/web-provider/test/Mina/MinaProvider.test.ts
@@ -8,6 +8,7 @@ import { Mina } from '@palladxyz/mina-core'
 import { Multichain } from '@palladxyz/multi-chain-core'
 import { KeyAgents, useVault } from '@palladxyz/vault'
 import { act, renderHook } from '@testing-library/react'
+import { vi } from 'vitest'
 
 import { MinaProvider } from '../../src/Mina'
 import { RequestArguments } from '../../src/Mina/types'
@@ -40,12 +41,6 @@ describe('WalletTest', () => {
   let agentArgs: FromBip39MnemonicWordsProps
   const keyAgentName = 'test key agent'
 
-  beforeAll(() => {
-    // Mock window.confirm to always return true (or false)
-    global.window = Object.create(window)
-    window.confirm = () => true
-  })
-
   beforeEach(async () => {
     agentArgs = {
       getPassphrase: getPassphrase,
@@ -70,6 +65,25 @@ describe('WalletTest', () => {
         archiveUrl: 'https://testworld.graphql.minaexplorer.com'
       }
     }
+
+    // Mock the global chrome object
+    global.chrome = {
+      windows: {
+        create: vi.fn() as unknown as typeof chrome.windows.create
+      },
+      runtime: {
+        sendMessage: vi.fn() as unknown as typeof chrome.runtime.sendMessage,
+        onMessage: {
+          addListener: vi.fn(),
+          removeListener: vi.fn()
+        } as unknown as typeof chrome.runtime.onMessage
+      }
+    } as unknown as typeof chrome
+  })
+
+  afterEach(() => {
+    // Reset the mocks after each test
+    vi.resetAllMocks()
   })
 
   it('should initialise the wallet and the provider should access the account info', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,9 @@ importers:
       '@palladxyz/vault':
         specifier: ^0.0.1
         version: link:../vault
+      vitest:
+        specifier: ^1.1.0
+        version: 1.1.0(@types/node@20.10.5)(happy-dom@12.10.3)
     devDependencies:
       '@palladxyz/common':
         specifier: ^1.0.0
@@ -771,6 +774,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.1.2
         version: 14.1.2(react-dom@18.2.0)(react@18.2.0)
+      '@types/chrome':
+        specifier: ^0.0.254
+        version: 0.0.254
       '@types/mocha':
         specifier: ^10.0.6
         version: 10.0.6
@@ -5414,6 +5420,13 @@ packages:
     resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
     dev: false
 
+  /@types/chrome@0.0.254:
+    resolution: {integrity: sha512-svkOGKwA+6ZZuk9xtrYun8MYpNY/9hD17rgZ19v3KunhsK1ZOKaMESw12/1AXLh1u3UPA8jQIRi2370DXv9wgw==}
+    dependencies:
+      '@types/filesystem': 0.0.35
+      '@types/har-format': 1.2.15
+    dev: true
+
   /@types/cookie@0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
@@ -5485,11 +5498,25 @@ packages:
     resolution: {integrity: sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==}
     dev: true
 
+  /@types/filesystem@0.0.35:
+    resolution: {integrity: sha512-1eKvCaIBdrD2mmMgy5dwh564rVvfEhZTWVQQGRNn0Nt4ZEnJ0C8oSUCzvMKRA4lGde5oEVo+q2MrTTbV/GHDCQ==}
+    dependencies:
+      '@types/filewriter': 0.0.32
+    dev: true
+
+  /@types/filewriter@0.0.32:
+    resolution: {integrity: sha512-Kpi2GXQyYJdjL8mFclL1eDgihn1SIzorMZjD94kdPZh9E4VxGOeyjPxi5LpsM4Zku7P0reqegZTt2GxhmA9VBg==}
+    dev: true
+
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 20.10.5
+    dev: true
+
+  /@types/har-format@1.2.15:
+    resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
     dev: true
 
   /@types/hast@3.0.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,9 @@ importers:
       '@palladxyz/vault':
         specifier: ^0.0.1
         version: link:../vault
+      mina-signer:
+        specifier: ^2.1.1
+        version: 2.1.1
       vitest:
         specifier: ^1.1.0
         version: 1.1.0(@types/node@20.10.5)(happy-dom@12.10.3)


### PR DESCRIPTION
## Describe changes
To communicate with zkApps, Pallad must be able to receive requests and provide back data; Pallad must be able to talk! It must do so by following a specific pattern. A good implementation of the injected provider means developers spend little time integrating a wallet Pallad, and users of Pallad have granular control over what information they do and do not provide when their wallet receives a request.

This implementation is modelled around [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) with the `mina_` prefix instead of the `eth_` prefix.

Tasks:
- [x] `mina_accounts` RPC Method
- [x] `mina_sign` RPC Method
- [ ] `mina_signTransaction`  RPC Method
- [ ] `mina_signFields`  RPC Method
- [ ] `mina_signMessage` RPC Method
- [ ] `mina_getBalance` RPC Method
- [ ] `mina_sendTransaction` RPC Method
- [ ] Correct event emitting
- [ ] Correct error handling
- [ ] Integrate into extension
