### PR TITLE
Feat: add $Pals handle service package

### DIFF
--- a/.github/workflows/apps-extension-ci.yml
+++ b/.github/workflows/apps-extension-ci.yml
@@ -37,17 +37,9 @@ jobs:
       VITE_APP_MODE: web
       VITE_APP_DEFAULT_NETWORK: Berkeley
       NODE_OPTIONS: '--max_old_space_size=4096'
-      PALS_SERVER_ENDPOINT: 'http://localhost:8000'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Pull Docker Image
-        run: docker pull teddyjfpender/pals:latest
-
-      - name: Start Docker Container
-        run: docker run -d -p 8000:8000 teddyjfpender/pals:latest
-
       - name: Setup env
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/apps-extension-ci.yml
+++ b/.github/workflows/apps-extension-ci.yml
@@ -37,7 +37,7 @@ jobs:
       VITE_APP_MODE: web
       VITE_APP_DEFAULT_NETWORK: Berkeley
       NODE_OPTIONS: '--max_old_space_size=4096'
-      PALS_SERVER_ENDPOINT: 'http:localhost:8000'
+      PALS_SERVER_ENDPOINT: 'http://localhost:8000'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/apps-extension-ci.yml
+++ b/.github/workflows/apps-extension-ci.yml
@@ -37,7 +37,7 @@ jobs:
       VITE_APP_MODE: web
       VITE_APP_DEFAULT_NETWORK: Berkeley
       NODE_OPTIONS: '--max_old_space_size=4096'
-      PALS_SERVER_ENDPOINT: 'http://172.17.0.2/8000'
+      PALS_SERVER_ENDPOINT: 'http:localhost:8000'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
 
       - name: Start Docker Container
         run: docker run -d -p 8000:8000 teddyjfpender/pals:latest
-        
+
       - name: Setup env
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/apps-extension-ci.yml
+++ b/.github/workflows/apps-extension-ci.yml
@@ -37,12 +37,17 @@ jobs:
       VITE_APP_MODE: web
       VITE_APP_DEFAULT_NETWORK: Berkeley
       NODE_OPTIONS: '--max_old_space_size=4096'
-      PALS_SERVER_ENDPOINT: 'http://localhost:8000'
+      PALS_SERVER_ENDPOINT: 'http://172.17.0.2/8000'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Pull Docker Image
         run: docker pull teddyjfpender/pals:latest
+
+      - name: Start Docker Container
+        run: docker run -d -p 8000:8000 teddyjfpender/pals:latest
+        
       - name: Setup env
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/apps-extension-ci.yml
+++ b/.github/workflows/apps-extension-ci.yml
@@ -37,9 +37,12 @@ jobs:
       VITE_APP_MODE: web
       VITE_APP_DEFAULT_NETWORK: Berkeley
       NODE_OPTIONS: '--max_old_space_size=4096'
+      PALS_SERVER_ENDPOINT: 'http://localhost:8000'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Pull Docker Image
+        run: docker pull teddyjfpender/pals:latest
       - name: Setup env
         uses: ./.github/actions/setup
         with:

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -94,6 +94,7 @@
     "superjson": "^2.2.1",
     "tailwind-merge": "^2.1.0",
     "tailwindcss-animate": "^1.0.7",
+    "tsup": "^8.0.1",
     "webextension-polyfill": "^0.10.0",
     "zod": "^3.22.4",
     "zustand": "^4.4.7"

--- a/packages/features/tsup.config.bundled_dkfa3luf586.mjs
+++ b/packages/features/tsup.config.bundled_dkfa3luf586.mjs
@@ -1,0 +1,158 @@
+// tsup.config.ts
+import { baseTsupConfig } from '@palladxyz/common'
+import svgJsx from '@svgr/plugin-jsx'
+import { polyfillNode } from 'esbuild-plugin-polyfill-node'
+import svgr from 'esbuild-plugin-svgr'
+import { defineConfig } from 'tsup'
+
+// package.json
+var package_default = {
+  name: '@palladxyz/features',
+  version: '0.1.0',
+  description: '',
+  type: 'module',
+  module: 'dist/index.js',
+  types: 'dist/index.d.ts',
+  exports: {
+    '.': {
+      types: './dist/index.d.ts',
+      default: './dist/index.js'
+    },
+    './dist/index.css': {
+      import: './dist/index.css',
+      require: './dist/index.css'
+    },
+    './tailwind.config.mjs': {
+      import: './tailwind.config.mjs',
+      require: './tailwind.config.mjs'
+    },
+    './postcss.config.mjs': {
+      import: './postcss.config.mjs',
+      require: './postcss.config.mjs'
+    }
+  },
+  scripts: {
+    build: 'tsup',
+    dev: 'tsup --watch',
+    'test:unit': "echo 'not yet'",
+    'story:dev': 'VITE_APP_LADLE=true ladle serve',
+    'story:build': 'VITE_APP_LADLE=true ladle build -o ./build',
+    'story:preview': 'VITE_APP_LADLE=true ladle preview',
+    cleanup: 'rimraf node_modules dist .turbo build'
+  },
+  dependencies: {
+    '@hookform/resolvers': '^3.3.2',
+    '@jitsu/jitsu-react': '^1.7.2',
+    '@palladxyz/key-management': '^0.0.1',
+    '@palladxyz/mina-core': '^0.0.1',
+    '@palladxyz/mina-graphql': '^0.0.1',
+    '@palladxyz/multi-chain-core': '^0.0.1',
+    '@palladxyz/offchain-data': '^1.0.0',
+    '@palladxyz/persistence': '^1.0.0',
+    '@palladxyz/vault': '^0.0.1',
+    '@radix-ui/react-accordion': '^1.1.2',
+    '@radix-ui/react-alert-dialog': '^1.0.5',
+    '@radix-ui/react-aspect-ratio': '^1.0.3',
+    '@radix-ui/react-avatar': '^1.0.4',
+    '@radix-ui/react-checkbox': '^1.0.4',
+    '@radix-ui/react-collapsible': '^1.0.3',
+    '@radix-ui/react-context-menu': '^2.1.5',
+    '@radix-ui/react-dialog': '^1.0.5',
+    '@radix-ui/react-dropdown-menu': '^2.0.6',
+    '@radix-ui/react-hover-card': '^1.0.7',
+    '@radix-ui/react-label': '^2.0.2',
+    '@radix-ui/react-menubar': '^1.0.4',
+    '@radix-ui/react-navigation-menu': '^1.1.4',
+    '@radix-ui/react-popover': '^1.0.7',
+    '@radix-ui/react-progress': '^1.0.3',
+    '@radix-ui/react-radio-group': '^1.1.3',
+    '@radix-ui/react-scroll-area': '^1.0.5',
+    '@radix-ui/react-select': '^2.0.0',
+    '@radix-ui/react-separator': '^1.0.3',
+    '@radix-ui/react-slider': '^1.1.2',
+    '@radix-ui/react-slot': '^1.0.2',
+    '@radix-ui/react-switch': '^1.0.3',
+    '@radix-ui/react-tabs': '^1.0.4',
+    '@radix-ui/react-toast': '^1.1.5',
+    '@radix-ui/react-toggle': '^1.0.3',
+    '@radix-ui/react-toggle-group': '^1.0.4',
+    '@radix-ui/react-tooltip': '^1.0.7',
+    '@total-typescript/ts-reset': '^0.5.1',
+    'class-variance-authority': '^0.7.0',
+    clsx: '^2.0.0',
+    cmdk: '^0.2.0',
+    'date-fns': '^3.0.1',
+    dayjs: '^1.11.10',
+    'easy-mesh-gradient': '^0.0.5',
+    immer: '^10.0.3',
+    'lucide-react': '^0.299.0',
+    'match-sorter': '^6.3.1',
+    'merge-refs': '^1.2.2',
+    'next-themes': '^0.2.1',
+    rambda: '^8.6.0',
+    react: '^18.2.0',
+    'react-day-picker': '^8.9.1',
+    'react-dom': '^18.2.0',
+    'react-hook-form': '^7.49.2',
+    'react-qr-code': '^2.0.12',
+    'react-router': '^6.21.0',
+    'react-router-dom': '^6.21.0',
+    'react-twc': '^1.0.1',
+    recharts: '^2.10.3',
+    superjson: '^2.2.1',
+    'tailwind-merge': '^2.1.0',
+    'tailwindcss-animate': '^1.0.7',
+    'webextension-polyfill': '^0.10.0',
+    zod: '^3.22.4',
+    zustand: '^4.4.7'
+  },
+  devDependencies: {
+    '@chialab/esbuild-plugin-commonjs': '^0.17.2',
+    '@hyrious/esbuild-plugin-commonjs': '^0.2.2',
+    '@ladle/react': '^4.0.2',
+    '@palladxyz/common': '^1.0.0',
+    '@svgr/plugin-jsx': '^8.0.1',
+    '@svgr/rollup': '^8.0.1',
+    '@testing-library/react': '^14.1.2',
+    '@trpc/server': '^10.44.1',
+    '@tsconfig/recommended': '^1.0.3',
+    '@tsconfig/vite-react': '^3.0.0',
+    '@types/mocha': '^10.0.6',
+    '@types/react': '^18.2.45',
+    '@types/react-dom': '^18.2.18',
+    '@types/webextension-polyfill': '^0.10.7',
+    'esbuild-plugin-polyfill-node': '^0.3.0',
+    'esbuild-plugin-svgr': '2.0.0',
+    'graphql-request': '^6.1.0',
+    'mina-signer': '^2.1.1',
+    swr: '^2.2.4',
+    vite: '^4.5.1',
+    'vite-plugin-node-polyfills': '^0.17.0',
+    'vite-plugin-svgr': '^3.2.0',
+    'vite-plugin-top-level-await': '^1.4.1'
+  },
+  peerDependencies: {
+    '@types/mocha': '^10.0.1',
+    react: '^18.2.0',
+    'react-dom': '^18.2.0'
+  }
+}
+
+// tsup.config.ts
+var tsup_config_default = defineConfig([
+  {
+    ...baseTsupConfig,
+    name: package_default.name,
+    esbuildPlugins: [
+      polyfillNode({
+        polyfills: { crypto: true },
+        globals: { process: true }
+      }),
+      svgr({ plugins: [svgJsx] })
+    ],
+    external: ['swr'],
+    treeshake: true
+  }
+])
+export { tsup_config_default as default }
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidHN1cC5jb25maWcudHMiLCAicGFja2FnZS5qc29uIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJjb25zdCBfX2luamVjdGVkX2ZpbGVuYW1lX18gPSBcIi9Vc2Vycy90aGVvZG9yZXBlbmRlci9Db2RpbmcvdHMtcHJvamVjdHMvcGFsbGFkL3BhY2thZ2VzL2ZlYXR1cmVzL3RzdXAuY29uZmlnLnRzXCI7Y29uc3QgX19pbmplY3RlZF9kaXJuYW1lX18gPSBcIi9Vc2Vycy90aGVvZG9yZXBlbmRlci9Db2RpbmcvdHMtcHJvamVjdHMvcGFsbGFkL3BhY2thZ2VzL2ZlYXR1cmVzXCI7Y29uc3QgX19pbmplY3RlZF9pbXBvcnRfbWV0YV91cmxfXyA9IFwiZmlsZTovLy9Vc2Vycy90aGVvZG9yZXBlbmRlci9Db2RpbmcvdHMtcHJvamVjdHMvcGFsbGFkL3BhY2thZ2VzL2ZlYXR1cmVzL3RzdXAuY29uZmlnLnRzXCI7aW1wb3J0IHsgYmFzZVRzdXBDb25maWcgfSBmcm9tICdAcGFsbGFkeHl6L2NvbW1vbidcbmltcG9ydCBzdmdKc3ggZnJvbSAnQHN2Z3IvcGx1Z2luLWpzeCdcbmltcG9ydCB7IHBvbHlmaWxsTm9kZSB9IGZyb20gJ2VzYnVpbGQtcGx1Z2luLXBvbHlmaWxsLW5vZGUnXG5pbXBvcnQgc3ZnciBmcm9tICdlc2J1aWxkLXBsdWdpbi1zdmdyJ1xuaW1wb3J0IHsgZGVmaW5lQ29uZmlnIH0gZnJvbSAndHN1cCcgLy8gZXNsaW50LWRpc2FibGUtbGluZSBpbXBvcnQvbm8tZXh0cmFuZW91cy1kZXBlbmRlbmNpZXNcblxuaW1wb3J0IHBhY2thZ2VKc29uIGZyb20gJy4vcGFja2FnZS5qc29uJ1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoW1xuICB7XG4gICAgLi4uYmFzZVRzdXBDb25maWcsXG4gICAgbmFtZTogcGFja2FnZUpzb24ubmFtZSxcbiAgICBlc2J1aWxkUGx1Z2luczogW1xuICAgICAgcG9seWZpbGxOb2RlKHtcbiAgICAgICAgcG9seWZpbGxzOiB7IGNyeXB0bzogdHJ1ZSB9LFxuICAgICAgICBnbG9iYWxzOiB7IHByb2Nlc3M6IHRydWUgfVxuICAgICAgfSksXG4gICAgICBzdmdyKHsgcGx1Z2luczogW3N2Z0pzeF0gfSlcbiAgICBdLFxuICAgIGV4dGVybmFsOiBbJ3N3ciddLFxuICAgIHRyZWVzaGFrZTogdHJ1ZVxuICB9XG5dKVxuIiwgIntcbiAgXCJuYW1lXCI6IFwiQHBhbGxhZHh5ei9mZWF0dXJlc1wiLFxuICBcInZlcnNpb25cIjogXCIwLjEuMFwiLFxuICBcImRlc2NyaXB0aW9uXCI6IFwiXCIsXG4gIFwidHlwZVwiOiBcIm1vZHVsZVwiLFxuICBcIm1vZHVsZVwiOiBcImRpc3QvaW5kZXguanNcIixcbiAgXCJ0eXBlc1wiOiBcImRpc3QvaW5kZXguZC50c1wiLFxuICBcImV4cG9ydHNcIjoge1xuICAgIFwiLlwiOiB7XG4gICAgICBcInR5cGVzXCI6IFwiLi9kaXN0L2luZGV4LmQudHNcIixcbiAgICAgIFwiZGVmYXVsdFwiOiBcIi4vZGlzdC9pbmRleC5qc1wiXG4gICAgfSxcbiAgICBcIi4vZGlzdC9pbmRleC5jc3NcIjoge1xuICAgICAgXCJpbXBvcnRcIjogXCIuL2Rpc3QvaW5kZXguY3NzXCIsXG4gICAgICBcInJlcXVpcmVcIjogXCIuL2Rpc3QvaW5kZXguY3NzXCJcbiAgICB9LFxuICAgIFwiLi90YWlsd2luZC5jb25maWcubWpzXCI6IHtcbiAgICAgIFwiaW1wb3J0XCI6IFwiLi90YWlsd2luZC5jb25maWcubWpzXCIsXG4gICAgICBcInJlcXVpcmVcIjogXCIuL3RhaWx3aW5kLmNvbmZpZy5tanNcIlxuICAgIH0sXG4gICAgXCIuL3Bvc3Rjc3MuY29uZmlnLm1qc1wiOiB7XG4gICAgICBcImltcG9ydFwiOiBcIi4vcG9zdGNzcy5jb25maWcubWpzXCIsXG4gICAgICBcInJlcXVpcmVcIjogXCIuL3Bvc3Rjc3MuY29uZmlnLm1qc1wiXG4gICAgfVxuICB9LFxuICBcInNjcmlwdHNcIjoge1xuICAgIFwiYnVpbGRcIjogXCJ0c3VwXCIsXG4gICAgXCJkZXZcIjogXCJ0c3VwIC0td2F0Y2hcIixcbiAgICBcInRlc3Q6dW5pdFwiOiBcImVjaG8gJ25vdCB5ZXQnXCIsXG4gICAgXCJzdG9yeTpkZXZcIjogXCJWSVRFX0FQUF9MQURMRT10cnVlIGxhZGxlIHNlcnZlXCIsXG4gICAgXCJzdG9yeTpidWlsZFwiOiBcIlZJVEVfQVBQX0xBRExFPXRydWUgbGFkbGUgYnVpbGQgLW8gLi9idWlsZFwiLFxuICAgIFwic3Rvcnk6cHJldmlld1wiOiBcIlZJVEVfQVBQX0xBRExFPXRydWUgbGFkbGUgcHJldmlld1wiLFxuICAgIFwiY2xlYW51cFwiOiBcInJpbXJhZiBub2RlX21vZHVsZXMgZGlzdCAudHVyYm8gYnVpbGRcIlxuICB9LFxuICBcImRlcGVuZGVuY2llc1wiOiB7XG4gICAgXCJAaG9va2Zvcm0vcmVzb2x2ZXJzXCI6IFwiXjMuMy4yXCIsXG4gICAgXCJAaml0c3Uvaml0c3UtcmVhY3RcIjogXCJeMS43LjJcIixcbiAgICBcIkBwYWxsYWR4eXova2V5LW1hbmFnZW1lbnRcIjogXCJeMC4wLjFcIixcbiAgICBcIkBwYWxsYWR4eXovbWluYS1jb3JlXCI6IFwiXjAuMC4xXCIsXG4gICAgXCJAcGFsbGFkeHl6L21pbmEtZ3JhcGhxbFwiOiBcIl4wLjAuMVwiLFxuICAgIFwiQHBhbGxhZHh5ei9tdWx0aS1jaGFpbi1jb3JlXCI6IFwiXjAuMC4xXCIsXG4gICAgXCJAcGFsbGFkeHl6L29mZmNoYWluLWRhdGFcIjogXCJeMS4wLjBcIixcbiAgICBcIkBwYWxsYWR4eXovcGVyc2lzdGVuY2VcIjogXCJeMS4wLjBcIixcbiAgICBcIkBwYWxsYWR4eXovdmF1bHRcIjogXCJeMC4wLjFcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1hY2NvcmRpb25cIjogXCJeMS4xLjJcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1hbGVydC1kaWFsb2dcIjogXCJeMS4wLjVcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1hc3BlY3QtcmF0aW9cIjogXCJeMS4wLjNcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1hdmF0YXJcIjogXCJeMS4wLjRcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1jaGVja2JveFwiOiBcIl4xLjAuNFwiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LWNvbGxhcHNpYmxlXCI6IFwiXjEuMC4zXCIsXG4gICAgXCJAcmFkaXgtdWkvcmVhY3QtY29udGV4dC1tZW51XCI6IFwiXjIuMS41XCIsXG4gICAgXCJAcmFkaXgtdWkvcmVhY3QtZGlhbG9nXCI6IFwiXjEuMC41XCIsXG4gICAgXCJAcmFkaXgtdWkvcmVhY3QtZHJvcGRvd24tbWVudVwiOiBcIl4yLjAuNlwiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LWhvdmVyLWNhcmRcIjogXCJeMS4wLjdcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1sYWJlbFwiOiBcIl4yLjAuMlwiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LW1lbnViYXJcIjogXCJeMS4wLjRcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1uYXZpZ2F0aW9uLW1lbnVcIjogXCJeMS4xLjRcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1wb3BvdmVyXCI6IFwiXjEuMC43XCIsXG4gICAgXCJAcmFkaXgtdWkvcmVhY3QtcHJvZ3Jlc3NcIjogXCJeMS4wLjNcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC1yYWRpby1ncm91cFwiOiBcIl4xLjEuM1wiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LXNjcm9sbC1hcmVhXCI6IFwiXjEuMC41XCIsXG4gICAgXCJAcmFkaXgtdWkvcmVhY3Qtc2VsZWN0XCI6IFwiXjIuMC4wXCIsXG4gICAgXCJAcmFkaXgtdWkvcmVhY3Qtc2VwYXJhdG9yXCI6IFwiXjEuMC4zXCIsXG4gICAgXCJAcmFkaXgtdWkvcmVhY3Qtc2xpZGVyXCI6IFwiXjEuMS4yXCIsXG4gICAgXCJAcmFkaXgtdWkvcmVhY3Qtc2xvdFwiOiBcIl4xLjAuMlwiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LXN3aXRjaFwiOiBcIl4xLjAuM1wiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LXRhYnNcIjogXCJeMS4wLjRcIixcbiAgICBcIkByYWRpeC11aS9yZWFjdC10b2FzdFwiOiBcIl4xLjEuNVwiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LXRvZ2dsZVwiOiBcIl4xLjAuM1wiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LXRvZ2dsZS1ncm91cFwiOiBcIl4xLjAuNFwiLFxuICAgIFwiQHJhZGl4LXVpL3JlYWN0LXRvb2x0aXBcIjogXCJeMS4wLjdcIixcbiAgICBcIkB0b3RhbC10eXBlc2NyaXB0L3RzLXJlc2V0XCI6IFwiXjAuNS4xXCIsXG4gICAgXCJjbGFzcy12YXJpYW5jZS1hdXRob3JpdHlcIjogXCJeMC43LjBcIixcbiAgICBcImNsc3hcIjogXCJeMi4wLjBcIixcbiAgICBcImNtZGtcIjogXCJeMC4yLjBcIixcbiAgICBcImRhdGUtZm5zXCI6IFwiXjMuMC4xXCIsXG4gICAgXCJkYXlqc1wiOiBcIl4xLjExLjEwXCIsXG4gICAgXCJlYXN5LW1lc2gtZ3JhZGllbnRcIjogXCJeMC4wLjVcIixcbiAgICBcImltbWVyXCI6IFwiXjEwLjAuM1wiLFxuICAgIFwibHVjaWRlLXJlYWN0XCI6IFwiXjAuMjk5LjBcIixcbiAgICBcIm1hdGNoLXNvcnRlclwiOiBcIl42LjMuMVwiLFxuICAgIFwibWVyZ2UtcmVmc1wiOiBcIl4xLjIuMlwiLFxuICAgIFwibmV4dC10aGVtZXNcIjogXCJeMC4yLjFcIixcbiAgICBcInJhbWJkYVwiOiBcIl44LjYuMFwiLFxuICAgIFwicmVhY3RcIjogXCJeMTguMi4wXCIsXG4gICAgXCJyZWFjdC1kYXktcGlja2VyXCI6IFwiXjguOS4xXCIsXG4gICAgXCJyZWFjdC1kb21cIjogXCJeMTguMi4wXCIsXG4gICAgXCJyZWFjdC1ob29rLWZvcm1cIjogXCJeNy40OS4yXCIsXG4gICAgXCJyZWFjdC1xci1jb2RlXCI6IFwiXjIuMC4xMlwiLFxuICAgIFwicmVhY3Qtcm91dGVyXCI6IFwiXjYuMjEuMFwiLFxuICAgIFwicmVhY3Qtcm91dGVyLWRvbVwiOiBcIl42LjIxLjBcIixcbiAgICBcInJlYWN0LXR3Y1wiOiBcIl4xLjAuMVwiLFxuICAgIFwicmVjaGFydHNcIjogXCJeMi4xMC4zXCIsXG4gICAgXCJzdXBlcmpzb25cIjogXCJeMi4yLjFcIixcbiAgICBcInRhaWx3aW5kLW1lcmdlXCI6IFwiXjIuMS4wXCIsXG4gICAgXCJ0YWlsd2luZGNzcy1hbmltYXRlXCI6IFwiXjEuMC43XCIsXG4gICAgXCJ3ZWJleHRlbnNpb24tcG9seWZpbGxcIjogXCJeMC4xMC4wXCIsXG4gICAgXCJ6b2RcIjogXCJeMy4yMi40XCIsXG4gICAgXCJ6dXN0YW5kXCI6IFwiXjQuNC43XCJcbiAgfSxcbiAgXCJkZXZEZXBlbmRlbmNpZXNcIjoge1xuICAgIFwiQGNoaWFsYWIvZXNidWlsZC1wbHVnaW4tY29tbW9uanNcIjogXCJeMC4xNy4yXCIsXG4gICAgXCJAaHlyaW91cy9lc2J1aWxkLXBsdWdpbi1jb21tb25qc1wiOiBcIl4wLjIuMlwiLFxuICAgIFwiQGxhZGxlL3JlYWN0XCI6IFwiXjQuMC4yXCIsXG4gICAgXCJAcGFsbGFkeHl6L2NvbW1vblwiOiBcIl4xLjAuMFwiLFxuICAgIFwiQHN2Z3IvcGx1Z2luLWpzeFwiOiBcIl44LjAuMVwiLFxuICAgIFwiQHN2Z3Ivcm9sbHVwXCI6IFwiXjguMC4xXCIsXG4gICAgXCJAdGVzdGluZy1saWJyYXJ5L3JlYWN0XCI6IFwiXjE0LjEuMlwiLFxuICAgIFwiQHRycGMvc2VydmVyXCI6IFwiXjEwLjQ0LjFcIixcbiAgICBcIkB0c2NvbmZpZy9yZWNvbW1lbmRlZFwiOiBcIl4xLjAuM1wiLFxuICAgIFwiQHRzY29uZmlnL3ZpdGUtcmVhY3RcIjogXCJeMy4wLjBcIixcbiAgICBcIkB0eXBlcy9tb2NoYVwiOiBcIl4xMC4wLjZcIixcbiAgICBcIkB0eXBlcy9yZWFjdFwiOiBcIl4xOC4yLjQ1XCIsXG4gICAgXCJAdHlwZXMvcmVhY3QtZG9tXCI6IFwiXjE4LjIuMThcIixcbiAgICBcIkB0eXBlcy93ZWJleHRlbnNpb24tcG9seWZpbGxcIjogXCJeMC4xMC43XCIsXG4gICAgXCJlc2J1aWxkLXBsdWdpbi1wb2x5ZmlsbC1ub2RlXCI6IFwiXjAuMy4wXCIsXG4gICAgXCJlc2J1aWxkLXBsdWdpbi1zdmdyXCI6IFwiMi4wLjBcIixcbiAgICBcImdyYXBocWwtcmVxdWVzdFwiOiBcIl42LjEuMFwiLFxuICAgIFwibWluYS1zaWduZXJcIjogXCJeMi4xLjFcIixcbiAgICBcInN3clwiOiBcIl4yLjIuNFwiLFxuICAgIFwidml0ZVwiOiBcIl40LjUuMVwiLFxuICAgIFwidml0ZS1wbHVnaW4tbm9kZS1wb2x5ZmlsbHNcIjogXCJeMC4xNy4wXCIsXG4gICAgXCJ2aXRlLXBsdWdpbi1zdmdyXCI6IFwiXjMuMi4wXCIsXG4gICAgXCJ2aXRlLXBsdWdpbi10b3AtbGV2ZWwtYXdhaXRcIjogXCJeMS40LjFcIlxuICB9LFxuICBcInBlZXJEZXBlbmRlbmNpZXNcIjoge1xuICAgIFwiQHR5cGVzL21vY2hhXCI6IFwiXjEwLjAuMVwiLFxuICAgIFwicmVhY3RcIjogXCJeMTguMi4wXCIsXG4gICAgXCJyZWFjdC1kb21cIjogXCJeMTguMi4wXCJcbiAgfVxufVxuIl0sCiAgIm1hcHBpbmdzIjogIjtBQUFpVixTQUFTLHNCQUFzQjtBQUNoWCxPQUFPLFlBQVk7QUFDbkIsU0FBUyxvQkFBb0I7QUFDN0IsT0FBTyxVQUFVO0FBQ2pCLFNBQVMsb0JBQW9COzs7QUNKN0I7QUFBQSxFQUNFLE1BQVE7QUFBQSxFQUNSLFNBQVc7QUFBQSxFQUNYLGFBQWU7QUFBQSxFQUNmLE1BQVE7QUFBQSxFQUNSLFFBQVU7QUFBQSxFQUNWLE9BQVM7QUFBQSxFQUNULFNBQVc7QUFBQSxJQUNULEtBQUs7QUFBQSxNQUNILE9BQVM7QUFBQSxNQUNULFNBQVc7QUFBQSxJQUNiO0FBQUEsSUFDQSxvQkFBb0I7QUFBQSxNQUNsQixRQUFVO0FBQUEsTUFDVixTQUFXO0FBQUEsSUFDYjtBQUFBLElBQ0EseUJBQXlCO0FBQUEsTUFDdkIsUUFBVTtBQUFBLE1BQ1YsU0FBVztBQUFBLElBQ2I7QUFBQSxJQUNBLHdCQUF3QjtBQUFBLE1BQ3RCLFFBQVU7QUFBQSxNQUNWLFNBQVc7QUFBQSxJQUNiO0FBQUEsRUFDRjtBQUFBLEVBQ0EsU0FBVztBQUFBLElBQ1QsT0FBUztBQUFBLElBQ1QsS0FBTztBQUFBLElBQ1AsYUFBYTtBQUFBLElBQ2IsYUFBYTtBQUFBLElBQ2IsZUFBZTtBQUFBLElBQ2YsaUJBQWlCO0FBQUEsSUFDakIsU0FBVztBQUFBLEVBQ2I7QUFBQSxFQUNBLGNBQWdCO0FBQUEsSUFDZCx1QkFBdUI7QUFBQSxJQUN2QixzQkFBc0I7QUFBQSxJQUN0Qiw2QkFBNkI7QUFBQSxJQUM3Qix3QkFBd0I7QUFBQSxJQUN4QiwyQkFBMkI7QUFBQSxJQUMzQiwrQkFBK0I7QUFBQSxJQUMvQiw0QkFBNEI7QUFBQSxJQUM1QiwwQkFBMEI7QUFBQSxJQUMxQixvQkFBb0I7QUFBQSxJQUNwQiw2QkFBNkI7QUFBQSxJQUM3QixnQ0FBZ0M7QUFBQSxJQUNoQyxnQ0FBZ0M7QUFBQSxJQUNoQywwQkFBMEI7QUFBQSxJQUMxQiw0QkFBNEI7QUFBQSxJQUM1QiwrQkFBK0I7QUFBQSxJQUMvQixnQ0FBZ0M7QUFBQSxJQUNoQywwQkFBMEI7QUFBQSxJQUMxQixpQ0FBaUM7QUFBQSxJQUNqQyw4QkFBOEI7QUFBQSxJQUM5Qix5QkFBeUI7QUFBQSxJQUN6QiwyQkFBMkI7QUFBQSxJQUMzQixtQ0FBbUM7QUFBQSxJQUNuQywyQkFBMkI7QUFBQSxJQUMzQiw0QkFBNEI7QUFBQSxJQUM1QiwrQkFBK0I7QUFBQSxJQUMvQiwrQkFBK0I7QUFBQSxJQUMvQiwwQkFBMEI7QUFBQSxJQUMxQiw2QkFBNkI7QUFBQSxJQUM3QiwwQkFBMEI7QUFBQSxJQUMxQix3QkFBd0I7QUFBQSxJQUN4QiwwQkFBMEI7QUFBQSxJQUMxQix3QkFBd0I7QUFBQSxJQUN4Qix5QkFBeUI7QUFBQSxJQUN6QiwwQkFBMEI7QUFBQSxJQUMxQixnQ0FBZ0M7QUFBQSxJQUNoQywyQkFBMkI7QUFBQSxJQUMzQiw4QkFBOEI7QUFBQSxJQUM5Qiw0QkFBNEI7QUFBQSxJQUM1QixNQUFRO0FBQUEsSUFDUixNQUFRO0FBQUEsSUFDUixZQUFZO0FBQUEsSUFDWixPQUFTO0FBQUEsSUFDVCxzQkFBc0I7QUFBQSxJQUN0QixPQUFTO0FBQUEsSUFDVCxnQkFBZ0I7QUFBQSxJQUNoQixnQkFBZ0I7QUFBQSxJQUNoQixjQUFjO0FBQUEsSUFDZCxlQUFlO0FBQUEsSUFDZixRQUFVO0FBQUEsSUFDVixPQUFTO0FBQUEsSUFDVCxvQkFBb0I7QUFBQSxJQUNwQixhQUFhO0FBQUEsSUFDYixtQkFBbUI7QUFBQSxJQUNuQixpQkFBaUI7QUFBQSxJQUNqQixnQkFBZ0I7QUFBQSxJQUNoQixvQkFBb0I7QUFBQSxJQUNwQixhQUFhO0FBQUEsSUFDYixVQUFZO0FBQUEsSUFDWixXQUFhO0FBQUEsSUFDYixrQkFBa0I7QUFBQSxJQUNsQix1QkFBdUI7QUFBQSxJQUN2Qix5QkFBeUI7QUFBQSxJQUN6QixLQUFPO0FBQUEsSUFDUCxTQUFXO0FBQUEsRUFDYjtBQUFBLEVBQ0EsaUJBQW1CO0FBQUEsSUFDakIsb0NBQW9DO0FBQUEsSUFDcEMsb0NBQW9DO0FBQUEsSUFDcEMsZ0JBQWdCO0FBQUEsSUFDaEIscUJBQXFCO0FBQUEsSUFDckIsb0JBQW9CO0FBQUEsSUFDcEIsZ0JBQWdCO0FBQUEsSUFDaEIsMEJBQTBCO0FBQUEsSUFDMUIsZ0JBQWdCO0FBQUEsSUFDaEIseUJBQXlCO0FBQUEsSUFDekIsd0JBQXdCO0FBQUEsSUFDeEIsZ0JBQWdCO0FBQUEsSUFDaEIsZ0JBQWdCO0FBQUEsSUFDaEIsb0JBQW9CO0FBQUEsSUFDcEIsZ0NBQWdDO0FBQUEsSUFDaEMsZ0NBQWdDO0FBQUEsSUFDaEMsdUJBQXVCO0FBQUEsSUFDdkIsbUJBQW1CO0FBQUEsSUFDbkIsZUFBZTtBQUFBLElBQ2YsS0FBTztBQUFBLElBQ1AsTUFBUTtBQUFBLElBQ1IsOEJBQThCO0FBQUEsSUFDOUIsb0JBQW9CO0FBQUEsSUFDcEIsK0JBQStCO0FBQUEsRUFDakM7QUFBQSxFQUNBLGtCQUFvQjtBQUFBLElBQ2xCLGdCQUFnQjtBQUFBLElBQ2hCLE9BQVM7QUFBQSxJQUNULGFBQWE7QUFBQSxFQUNmO0FBQ0Y7OztBRDFIQSxJQUFPLHNCQUFRLGFBQWE7QUFBQSxFQUMxQjtBQUFBLElBQ0UsR0FBRztBQUFBLElBQ0gsTUFBTSxnQkFBWTtBQUFBLElBQ2xCLGdCQUFnQjtBQUFBLE1BQ2QsYUFBYTtBQUFBLFFBQ1gsV0FBVyxFQUFFLFFBQVEsS0FBSztBQUFBLFFBQzFCLFNBQVMsRUFBRSxTQUFTLEtBQUs7QUFBQSxNQUMzQixDQUFDO0FBQUEsTUFDRCxLQUFLLEVBQUUsU0FBUyxDQUFDLE1BQU0sRUFBRSxDQUFDO0FBQUEsSUFDNUI7QUFBQSxJQUNBLFVBQVUsQ0FBQyxLQUFLO0FBQUEsSUFDaEIsV0FBVztBQUFBLEVBQ2I7QUFDRixDQUFDOyIsCiAgIm5hbWVzIjogW10KfQo=

--- a/packages/pals/README.md
+++ b/packages/pals/README.md
@@ -1,0 +1,4 @@
+# @palladxyz/pals
+
+This TypeScript library creates Providers that can read data from the Pals handle service.
+

--- a/packages/pals/package.json
+++ b/packages/pals/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@palladxyz/pals",
+  "version": "0.0.1",
+  "description": "Package for interacting with the $Pals handle service",
+  "type": "module",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test:unit": "vitest run",
+    "cleanup": "rimraf node_modules dist .turbo"
+  },
+  "devDependencies": {
+    "@palladxyz/common": "^1.0.0",
+    "@types/mocha": "^10.0.6",
+    "esbuild-plugin-polyfill-node": "^0.3.0"
+  }
+}

--- a/packages/pals/package.json
+++ b/packages/pals/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@palladxyz/common": "^1.0.0",
     "@types/mocha": "^10.0.6",
-    "esbuild-plugin-polyfill-node": "^0.3.0"
+    "esbuild-plugin-polyfill-node": "^0.3.0",
+    "msw": "^2.1.4"
   }
 }

--- a/packages/pals/src/index.ts
+++ b/packages/pals/src/index.ts
@@ -1,0 +1,1 @@
+export * from './pals-provider'

--- a/packages/pals/src/pals-provider/index.ts
+++ b/packages/pals/src/pals-provider/index.ts
@@ -1,0 +1,1 @@
+export * from './provider'

--- a/packages/pals/src/pals-provider/provider/index.ts
+++ b/packages/pals/src/pals-provider/provider/index.ts
@@ -1,0 +1,1 @@
+export * from './pals-handle-provider'

--- a/packages/pals/src/pals-provider/provider/pals-handle-provider.ts
+++ b/packages/pals/src/pals-provider/provider/pals-handle-provider.ts
@@ -1,0 +1,67 @@
+import { fetchPals } from '../utils/fetch-utils'
+import { healthCheck, HealthCheckResponse } from '../utils/health-check-utils'
+
+export type getAddressFromHandleArgs = {
+  handle: string
+}
+
+export type getAddressFromHandleResponse = {
+  address: string
+}
+
+export type getSearchAddressFromPartialResponse = {
+  addresses: string[]
+}
+
+export interface PalsHandleProvider {
+  healthCheck: () => Promise<HealthCheckResponse>
+  getAddressFromHandle: (
+    args: getAddressFromHandleArgs
+  ) => Promise<getAddressFromHandleResponse>
+  getSearchedHandles: (
+    args: getAddressFromHandleArgs
+  ) => Promise<getSearchAddressFromPartialResponse>
+}
+
+export const createPalsHandleProvider = (url: string): PalsHandleProvider => {
+  const getAddressFromHandle = async (
+    args: getAddressFromHandleArgs
+  ): Promise<getAddressFromHandleResponse> => {
+    const result = await fetchPals(url + `/address/${args.handle}`)
+
+    if (!result.ok) {
+      throw new Error(result.message)
+    }
+
+    const responseData = result.data
+    const responseObject: getAddressFromHandleResponse = {
+      address: responseData.address
+    }
+
+    return responseObject
+  }
+
+  const getSearchedHandles = async (
+    args: getAddressFromHandleArgs
+  ): Promise<getSearchAddressFromPartialResponse> => {
+    const queryParams = { moniker: args.handle }
+    const result = await fetchPals(url + `/search`, queryParams)
+
+    if (!result.ok) {
+      throw new Error(result.message)
+    }
+
+    const responseData = result.data
+    const responseObject: getSearchAddressFromPartialResponse = {
+      addresses: responseData
+    }
+
+    return responseObject
+  }
+
+  return {
+    healthCheck: () => healthCheck(url),
+    getSearchedHandles,
+    getAddressFromHandle
+  }
+}

--- a/packages/pals/src/pals-provider/utils/fetch-utils.ts
+++ b/packages/pals/src/pals-provider/utils/fetch-utils.ts
@@ -1,0 +1,44 @@
+export const fetchPals = async (
+  url: string,
+  queryParams?: Record<string, string>
+) => {
+  try {
+    let queryUrl = url
+
+    // Add query parameters to the URL if they exist
+    if (queryParams) {
+      const queryParamString = new URLSearchParams(queryParams).toString()
+      queryUrl = `${url}?${queryParamString}`
+    }
+
+    const response = await fetch(queryUrl, {
+      method: 'GET'
+    })
+
+    if (!response.ok) {
+      return { ok: false, message: `HTTP error! status: ${response.status}` }
+    }
+
+    const data = await response.json()
+
+    // Checking directly for data in the respose
+    if (data) {
+      return { ok: true, data: data } // Directly returning the data
+    }
+
+    // Additional error handling as per your API's design
+    if (data.errors) {
+      return {
+        ok: false,
+        message: `Error: ${data.errors.map((e: any) => e.message).join(', ')}`
+      }
+    }
+
+    return { ok: false, message: 'Data not found' }
+  } catch (error) {
+    if (error instanceof Error) {
+      return { ok: false, message: `Error: ${error.message}` }
+    }
+    return { ok: false, message: 'An unknown error occurred' }
+  }
+}

--- a/packages/pals/src/pals-provider/utils/health-check-utils.ts
+++ b/packages/pals/src/pals-provider/utils/health-check-utils.ts
@@ -1,0 +1,19 @@
+import { fetchPals } from './fetch-utils'
+
+export type HealthCheckResponse = {
+  ok: boolean
+  message: string
+}
+
+export const healthCheck = async (
+  url: string
+): Promise<HealthCheckResponse> => {
+  const result = await fetchPals(url + `/health`)
+  if (!result.ok) {
+    return { ok: result.ok, message: result.message as string }
+  }
+  return {
+    ok: result.ok,
+    message: result.data
+  }
+}

--- a/packages/pals/src/pals-provider/utils/index.ts
+++ b/packages/pals/src/pals-provider/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './fetch-utils'
+export * from './health-check-utils'

--- a/packages/pals/test/provider/mocks/handlers.ts
+++ b/packages/pals/test/provider/mocks/handlers.ts
@@ -1,0 +1,26 @@
+import { http, HttpResponse } from 'msw'
+
+export const handlers = [
+  // Mock GET request to /address/:handle
+  http.get('/address/$teddy', () => {
+    return HttpResponse.json({
+      address: 'B62qs2mR2g7LB27P36MhxN5jnsnjS8t6azttZfCnAToVpCmTtRVT2nt'
+    })
+  }),
+
+  // Mock GET request to /search
+  http.get('/search', () => {
+    return HttpResponse.json([
+      'Address1',
+      'Address2',
+      'Address3',
+      'Address4',
+      'Address5'
+    ])
+  }),
+
+  // Mock GET request to /health
+  http.get('/health', () => {
+    return HttpResponse.json('Server is healthy')
+  })
+]

--- a/packages/pals/test/provider/pals-handle-provider.test.ts
+++ b/packages/pals/test/provider/pals-handle-provider.test.ts
@@ -1,12 +1,13 @@
 import { createPalsHandleProvider } from '../../src'
+const url = process.env['PALS_SERVER_ENDPOINT'] || ''
 
 describe('createPalsHandleProvider', () => {
   it('should create a pals handle provider', () => {
-    const palsHandleProvider = createPalsHandleProvider('http://127.0.0.1:8000')
+    const palsHandleProvider = createPalsHandleProvider(url)
     expect(palsHandleProvider).toBeDefined()
   })
   it('should get an address from a handle', async () => {
-    const palsHandleProvider = createPalsHandleProvider('http://127.0.0.1:8000')
+    const palsHandleProvider = createPalsHandleProvider(url)
     const result = await palsHandleProvider.getAddressFromHandle({
       handle: '$teddy'
     })
@@ -16,13 +17,13 @@ describe('createPalsHandleProvider', () => {
     )
   })
   it('should check health of Pals Handle Provider', async () => {
-    const palsHandleProvider = createPalsHandleProvider('http://127.0.0.1:8000')
+    const palsHandleProvider = createPalsHandleProvider(url)
     const result = await palsHandleProvider.healthCheck()
     expect(result.ok).toBe(true)
     expect(result.message).toBe('Server is healthy')
   })
   it('should get a list of addresses from a partial handle', async () => {
-    const palsHandleProvider = createPalsHandleProvider('http://127.0.0.1:8000')
+    const palsHandleProvider = createPalsHandleProvider(url)
     const result = await palsHandleProvider.getSearchedHandles({ handle: '$' })
     console.log('Search result', result)
     expect(result.addresses).toHaveLength(5)

--- a/packages/pals/test/provider/pals-handle-provider.test.ts
+++ b/packages/pals/test/provider/pals-handle-provider.test.ts
@@ -1,31 +1,36 @@
+import './test-setup'
+
 import { createPalsHandleProvider } from '../../src'
-const url = process.env['PALS_SERVER_ENDPOINT'] || ''
+
+const relativeUrl = ''
 
 describe('createPalsHandleProvider', () => {
   it('should create a pals handle provider', () => {
-    const palsHandleProvider = createPalsHandleProvider(url)
+    const palsHandleProvider = createPalsHandleProvider(relativeUrl)
     expect(palsHandleProvider).toBeDefined()
   })
+
   it('should get an address from a handle', async () => {
-    const palsHandleProvider = createPalsHandleProvider(url)
+    const palsHandleProvider = createPalsHandleProvider(relativeUrl)
     const result = await palsHandleProvider.getAddressFromHandle({
       handle: '$teddy'
     })
-    console.log('Address result', result)
     expect(result.address).toBe(
       'B62qs2mR2g7LB27P36MhxN5jnsnjS8t6azttZfCnAToVpCmTtRVT2nt'
     )
   })
+
   it('should check health of Pals Handle Provider', async () => {
-    const palsHandleProvider = createPalsHandleProvider(url)
+    const palsHandleProvider = createPalsHandleProvider(relativeUrl)
     const result = await palsHandleProvider.healthCheck()
+    console.log('Pals Handle Provider Health Check Response', result)
     expect(result.ok).toBe(true)
     expect(result.message).toBe('Server is healthy')
   })
+
   it('should get a list of addresses from a partial handle', async () => {
-    const palsHandleProvider = createPalsHandleProvider(url)
+    const palsHandleProvider = createPalsHandleProvider(relativeUrl)
     const result = await palsHandleProvider.getSearchedHandles({ handle: '$' })
-    console.log('Search result', result)
     expect(result.addresses).toHaveLength(5)
   })
 })

--- a/packages/pals/test/provider/pals-handle-provider.test.ts
+++ b/packages/pals/test/provider/pals-handle-provider.test.ts
@@ -1,0 +1,30 @@
+import { createPalsHandleProvider } from '../../src'
+
+describe('createPalsHandleProvider', () => {
+  it('should create a pals handle provider', () => {
+    const palsHandleProvider = createPalsHandleProvider('http://127.0.0.1:8000')
+    expect(palsHandleProvider).toBeDefined()
+  })
+  it('should get an address from a handle', async () => {
+    const palsHandleProvider = createPalsHandleProvider('http://127.0.0.1:8000')
+    const result = await palsHandleProvider.getAddressFromHandle({
+      handle: '$teddy'
+    })
+    console.log('Address result', result)
+    expect(result.address).toBe(
+      'B62qs2mR2g7LB27P36MhxN5jnsnjS8t6azttZfCnAToVpCmTtRVT2nt'
+    )
+  })
+  it('should check health of Pals Handle Provider', async () => {
+    const palsHandleProvider = createPalsHandleProvider('http://127.0.0.1:8000')
+    const result = await palsHandleProvider.healthCheck()
+    expect(result.ok).toBe(true)
+    expect(result.message).toBe('Server is healthy')
+  })
+  it('should get a list of addresses from a partial handle', async () => {
+    const palsHandleProvider = createPalsHandleProvider('http://127.0.0.1:8000')
+    const result = await palsHandleProvider.getSearchedHandles({ handle: '$' })
+    console.log('Search result', result)
+    expect(result.addresses).toHaveLength(5)
+  })
+})

--- a/packages/pals/test/provider/test-setup.ts
+++ b/packages/pals/test/provider/test-setup.ts
@@ -1,0 +1,9 @@
+import { setupServer } from 'msw/node'
+
+import { handlers } from './mocks/handlers'
+
+export const server = setupServer(...handlers)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())

--- a/packages/pals/tsconfig.json
+++ b/packages/pals/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@palladxyz/common/tsconfig.json"
+}

--- a/packages/pals/tsup.config.ts
+++ b/packages/pals/tsup.config.ts
@@ -1,0 +1,17 @@
+import { baseTsupConfig } from '@palladxyz/common'
+import { polyfillNode } from 'esbuild-plugin-polyfill-node'
+import { defineConfig } from 'tsup' // eslint-disable-line import/no-extraneous-dependencies
+
+import packageJson from './package.json'
+
+export default defineConfig([
+  {
+    ...baseTsupConfig,
+    name: packageJson.name,
+    esbuildPlugins: [
+      polyfillNode({
+        polyfills: { punycode: true }
+      })
+    ]
+  }
+])

--- a/packages/pals/vitest.config.ts
+++ b/packages/pals/vitest.config.ts
@@ -1,0 +1,6 @@
+import { baseVitestConfig } from '@palladxyz/common'
+import { defineConfig } from 'vitest/config' // eslint-disable-line import/no-extraneous-dependencies
+
+export default defineConfig({
+  ...baseVitestConfig
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.0)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.0.1(postcss@8.4.32)(typescript@5.3.3)
       webextension-polyfill:
         specifier: ^0.10.0
         version: 0.10.0
@@ -662,6 +665,18 @@ importers:
       '@palladxyz/common':
         specifier: ^1.0.0
         version: link:../common
+
+  packages/pals:
+    devDependencies:
+      '@palladxyz/common':
+        specifier: ^1.0.0
+        version: link:../common
+      '@types/mocha':
+        specifier: ^10.0.6
+        version: 10.0.6
+      esbuild-plugin-polyfill-node:
+        specifier: ^0.3.0
+        version: 0.3.0(esbuild@0.19.11)
 
   packages/persistence:
     dependencies:
@@ -6361,7 +6376,6 @@ packages:
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-    dev: true
 
   /array-union@3.0.1:
     resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
@@ -6788,7 +6802,6 @@ packages:
     dependencies:
       esbuild: 0.19.11
       load-tsconfig: 0.2.5
-    dev: true
 
   /bunyan@1.8.15:
     resolution: {integrity: sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==}
@@ -7870,7 +7883,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
-    dev: true
 
   /direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
@@ -8872,7 +8884,6 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-    dev: true
 
   /execa@7.2.0:
     resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
@@ -9267,7 +9278,6 @@ packages:
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-    dev: true
 
   /get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -9407,7 +9417,6 @@ packages:
       ignore: 5.3.0
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
 
   /globby@13.2.2:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
@@ -9859,7 +9868,6 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-    dev: true
 
   /human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
@@ -9895,7 +9903,6 @@ packages:
   /ignore@5.3.0:
     resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
     engines: {node: '>= 4'}
-    dev: true
 
   /image-size@1.0.2:
     resolution: {integrity: sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==}
@@ -10287,7 +10294,6 @@ packages:
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -10499,7 +10505,6 @@ packages:
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
-    dev: true
 
   /js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -10772,7 +10777,6 @@ packages:
   /load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
 
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
@@ -10805,7 +10809,6 @@ packages:
 
   /lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
-    dev: true
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -11575,7 +11578,6 @@ packages:
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
-    dev: true
 
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -12014,7 +12016,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
-    dev: true
 
   /npm-run-path@5.2.0:
     resolution: {integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==}
@@ -12113,7 +12114,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mimic-fn: 2.1.0
-    dev: true
 
   /onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -12425,7 +12425,6 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-type@5.0.0:
     resolution: {integrity: sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==}
@@ -12766,7 +12765,6 @@ packages:
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-    dev: true
 
   /pupa@3.1.0:
     resolution: {integrity: sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==}
@@ -13365,7 +13363,6 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: true
 
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
@@ -13711,7 +13708,6 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-    dev: true
 
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -13731,7 +13727,6 @@ packages:
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
@@ -13812,7 +13807,6 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       whatwg-url: 7.1.0
-    dev: true
 
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -14057,7 +14051,6 @@ packages:
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
-    dev: true
 
   /strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -14396,12 +14389,10 @@ packages:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
       punycode: 2.3.1
-    dev: true
 
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
-    dev: true
 
   /trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -14534,7 +14525,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-node
-    dev: true
 
   /tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
@@ -14723,7 +14713,6 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /uberproto@1.2.0:
     resolution: {integrity: sha512-pGtPAQmLwh+R9w81WVHzui1FfedpQWQpiaIIfPCwhtsBez4q6DYbJFfyXPVHPUTNFnedAvNEnkoFiLuhXIR94w==}
@@ -15562,7 +15551,6 @@ packages:
 
   /webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
-    dev: true
 
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -15595,7 +15583,6 @@ packages:
       lodash.sortby: 4.7.0
       tr46: 1.0.1
       webidl-conversions: 4.0.2
-    dev: true
 
   /when@3.7.7:
     resolution: {integrity: sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,9 @@ importers:
       esbuild-plugin-polyfill-node:
         specifier: ^0.3.0
         version: 0.3.0(esbuild@0.19.11)
+      msw:
+        specifier: ^2.1.4
+        version: 2.1.4(typescript@5.3.3)
 
   packages/persistence:
     dependencies:
@@ -3200,6 +3203,18 @@ packages:
       strict-event-emitter: 0.5.1
     dev: true
 
+  /@mswjs/interceptors@0.25.14:
+    resolution: {integrity: sha512-2dnIxl+obqIqjoPXTFldhe6pcdOrqiz+GcLaQQ6hmL02OldAF7nIC+rUgTWm+iF6lvmyCVhFFqbgbapNhR8eag==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      strict-event-emitter: 0.5.1
+    dev: true
+
   /@next/env@14.0.4:
     resolution: {integrity: sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ==}
     dev: false
@@ -5537,6 +5552,10 @@ packages:
 
   /@types/cookie@0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
+    dev: true
+
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
     dev: true
 
   /@types/d3-array@3.2.1:
@@ -11746,6 +11765,38 @@ packages:
       yargs: 17.7.2
     dev: true
 
+  /msw@2.1.4(typescript@5.3.3):
+    resolution: {integrity: sha512-YyIQpfLqAJf/O1kYPWBSbDqjgv71kRBmEbGLxkkai1Btcs/LcxKiAwT1My3COa9J/vTh9Ua41B/ReuiW9cXmkw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.7.x <= 5.3.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/statuses': 1.0.1
+      '@mswjs/cookies': 1.1.0
+      '@mswjs/interceptors': 0.25.14
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.4
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      graphql: 16.8.1
+      headers-polyfill: 4.0.2
+      inquirer: 8.2.6
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      path-to-regexp: 6.2.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.10.1
+      typescript: 5.3.3
+      yargs: 17.7.2
+    dev: true
+
   /multimatch@6.0.0:
     resolution: {integrity: sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -14652,6 +14703,11 @@ packages:
   /type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
+
+  /type-fest@4.10.1:
+    resolution: {integrity: sha512-7ZnJYTp6uc04uYRISWtiX3DSKB/fxNQT0B5o1OUeCqiQiwF+JC9+rJiZIDrPrNCLLuTqyQmh4VdQqh/ZOkv9MQ==}
+    engines: {node: '>=16'}
+    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}


### PR DESCRIPTION
## Describe changes
This PR adds a new `pals` package; it allows users to query the `$Pals` server via a TypeScript provider.

## Benefits
With this new service and its provider, Pallad will be able to resolve handles to addresses. For example, `$teddy` can be resolved to `B62qs...T2nt`, offering an improved user experience.

TODO:
- [ ] Deploy Pals Server
