### PR TITLE
chore(repo): add adr template

### DIFF
--- a/docs/adr/000-adr-template.md
+++ b/docs/adr/000-adr-template.md
@@ -1,0 +1,29 @@
+# ADR Template
+
+| Status        | (Proposed / Accepted / Implemented / Obsolete)       |
+:-------------- |:---------------------------------------------------- |
+| **Author(s)** | John Doe (john@doe.com)                              |
+| **Updated**   | 2024-01-25                                           |
+
+## Context and Problem Statement
+
+Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
+You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+## Considered Options
+
+- Option 1
+- Option 2
+
+## Decision Outcome
+
+Chosen option: "Option 1", because
+{justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+### Consequences
+
+Describe the actual or potential consequences of the decision made.
+
+## Validation
+
+{describe how the implementation of/compliance with the ADR is validated.

--- a/docs/adr/001-rfc-adr-process.md
+++ b/docs/adr/001-rfc-adr-process.md
@@ -1,0 +1,26 @@
+# RFC/ADR Process
+
+| Status        | Implemented                                          |
+:-------------- |:---------------------------------------------------- |
+| **Author(s)** | Tomasz Marciniak (tomek@palladians.xyz)              |
+| **Updated**   | 2024-01-25                                           |
+
+## Context and Problem Statement
+
+We want to build this wallet as close to the community as possible. That's why, based on our software development experience, we decided to implement the RFC/ADR process. The most important architectural decisions should go through this process to hear the voice of the community.
+
+## Considered Options
+
+- Option 1: When we need to make a major architectural decision, we first post a Request for Comments and let the community voice their opinions and concerns for at least a few days. After most of the unknowns have been addressed, we can proceed to propose a decision in the Architecture Decision Record. If most of the core team agrees, the ADR gets a new status and should be respected accordingly.
+
+## Decision Outcome
+
+The potential outcome of this decision is that we will be able to build the wallet closer to the end user, listening to their opinions and concerns.
+
+### Consequences
+
+The process may make the decision process longer, but it's better to make the decision a little longer than to make a bad decision.
+
+## Validation
+
+We will benchmark this process with the upcoming RFC and ADR entries.

--- a/docs/rfc/000-rfc-template.md
+++ b/docs/rfc/000-rfc-template.md
@@ -1,0 +1,34 @@
+# RFC Template
+
+| Status        | (Proposed / Accepted / Implemented / Obsolete)       |
+:-------------- |:---------------------------------------------------- |
+| **Author(s)** | John Doe (john@doe.com)                              |
+| **Updated**   | 2024-01-25                                           |
+
+## Objective
+
+Describe the purpose of the proposed discussion.
+
+## Motivation
+
+Provide context about the motivation for starting the discussion.
+
+## User Benefit
+
+What would be the potential benefit of taking action in a specific case?
+
+## Design Proposal
+
+Suggest the best solution to the problem outlined from your perspective.
+
+### Alternatives Considered
+
+Describe the alternatives to your proposal.
+
+### Dependencies
+
+Does this RFC depend on other discussions or decisions (especially those documented in ADRs)?
+
+## Unresolved questions
+
+If there are unresolved issues related to this RFC, please outline them here.

--- a/docs/rfc/001-rfc-adr-process.md
+++ b/docs/rfc/001-rfc-adr-process.md
@@ -1,10 +1,9 @@
 # RFC/ADR Process Introduction
 
-| Status        | (Proposed / Accepted / Implemented / Obsolete)       |
+| Status        | Implemented                                          |
 :-------------- |:---------------------------------------------------- |
 | **Author(s)** | Tomasz Marciniak (tomek@palladians.xyz)              |
 | **Updated**   | 2024-01-24                                           |
-| **Obsoletes** | N/A                                                  |
 
 ## Objective
 


### PR DESCRIPTION
## Describe changes
- Adds a directory for ADRs.
- Adds templates for both RFC and ADR.
- Adds first entries for RFC and ADR around the process.

## Ticket or discussion link

## Review checklist

- [ ] Proper documentation added
- [ ] Proper tests added

## Screenshots
