### PR TITLE
feat: zeko providers

### DIFF
--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,3 +1,4 @@
 export * as MinaExplorer from './mina-explorer'
+export * as MinaNode from './mina-node'
 export * as Obscura from './obscura-provider'
 export * from './unified-providers'

--- a/packages/providers/src/mina-node/account-info/account-info-provider.ts
+++ b/packages/providers/src/mina-node/account-info/account-info-provider.ts
@@ -1,0 +1,48 @@
+import {
+  AccountInfo,
+  AccountInfoArgs,
+  AccountInfoProvider
+} from '@palladxyz/mina-core'
+
+import { createGraphQLRequest } from '../utils/fetch-utils'
+import { healthCheck } from '../utils/health-check-utils'
+import { getTokenAccountInfoQuery } from './queries'
+
+export const createAccountInfoProvider = (url: string): AccountInfoProvider => {
+  const getAccountInfo = async (
+    args: AccountInfoArgs
+  ): Promise<Record<string, AccountInfo>> => {
+    const variables = { publicKey: args.publicKey }
+    const query = getTokenAccountInfoQuery(args.tokenMap || { MINA: '1' })
+    const fetchGraphQL = createGraphQLRequest(url)
+    const result = await fetchGraphQL(query, variables)
+
+    if (!result.ok) {
+      throw new Error(result.message)
+    }
+
+    const accountsData = result.data
+    const accountsInfo: Record<string, AccountInfo> = {}
+
+    for (const [key, account] of Object.entries(accountsData)) {
+      if (account === null) {
+        accountsInfo[key] = {
+          balance: { total: 0 },
+          nonce: 0,
+          inferredNonce: 0,
+          delegate: '',
+          publicKey: args.publicKey
+        }
+      } else {
+        accountsInfo[key] = account as AccountInfo
+      }
+    }
+
+    return accountsInfo
+  }
+
+  return {
+    healthCheck: () => healthCheck(url),
+    getAccountInfo
+  }
+}

--- a/packages/providers/src/mina-node/account-info/index.ts
+++ b/packages/providers/src/mina-node/account-info/index.ts
@@ -1,0 +1,1 @@
+export * from './account-info-provider'

--- a/packages/providers/src/mina-node/account-info/queries.ts
+++ b/packages/providers/src/mina-node/account-info/queries.ts
@@ -1,0 +1,35 @@
+export const healthCheckQuery = `
+{
+  syncStatus
+}
+`
+
+export const getAccountBalance = `
+  query accountBalance($publicKey: PublicKey!) {
+    account(publicKey: $publicKey) {
+      balance {
+        total
+      },
+      nonce
+      inferredNonce
+      delegate
+      publicKey
+    }
+  }
+`
+import { TokenIdMap } from '@palladxyz/mina-core'
+
+export function getTokenAccountInfoQuery(tokenIds: TokenIdMap): string {
+  // Start with the base part of the query
+  let queryString = `query tokenQuery($publicKey: PublicKey!) {\n`
+
+  // Dynamically add account queries based on tokenIds
+  Object.entries(tokenIds).forEach(([alias, tokenId]) => {
+    queryString += `  ${alias}: account(token: "${tokenId}", publicKey: $publicKey) {\n    ...AccountFields\n  }\n`
+  })
+
+  // Add the fragment definition
+  queryString += `}\n\nfragment AccountFields on Account {\n  balance {\n    total\n  }\n  tokenSymbol\n  tokenId\n  nonce\n  inferredNonce\n  publicKey\n  delegate\n}`
+
+  return queryString
+}

--- a/packages/providers/src/mina-node/block-listener/BlockListenerProvider.ts
+++ b/packages/providers/src/mina-node/block-listener/BlockListenerProvider.ts
@@ -1,0 +1,113 @@
+import { AccountInfo, AccountInfoArgs } from '@palladxyz/mina-core'
+import { ExecutionResult } from 'graphql'
+import { gql, GraphQLClient } from 'graphql-request'
+import { SubscriptionClient } from 'subscriptions-transport-ws'
+
+import {
+  AccountData,
+  AccountInfoGraphQLProvider
+} from '../account-info/AccountInfoProvider'
+import { getAccountBalance } from '../account-info/queries'
+
+interface BlockData {
+  newBlock?: {
+    creator?: string
+    stateHash?: string
+    protocolState?: {
+      consensusState?: {
+        blockHeight?: number
+      }
+      previousStateHash?: string
+    }
+  }
+}
+
+export class BlockListenerProvider {
+  private accountInfoProvider: AccountInfoGraphQLProvider
+  private subscriptionClient: SubscriptionClient
+  private gqlClient: GraphQLClient
+
+  constructor(minaGql: string, wsEndpoint: string) {
+    this.accountInfoProvider = new AccountInfoGraphQLProvider(minaGql)
+    this.subscriptionClient = new SubscriptionClient(wsEndpoint, {
+      reconnect: true
+    })
+    this.gqlClient = new GraphQLClient(minaGql)
+  }
+
+  listenToNewBlocks(publicKey: string) {
+    const subscription = gql`
+      subscription {
+        newBlock(publicKey: "${publicKey}") {
+          creator
+          stateHash
+          protocolState {
+            consensusState {
+              blockHeight
+            }
+            previousStateHash
+          }
+        }
+      }
+    `
+
+    return this.subscriptionClient
+      .request({
+        query: subscription
+      })
+      .subscribe({
+        next: async (result: ExecutionResult) => {
+          // Type guard
+          if ('data' in result && 'newBlock' in result.data) {
+            const data: BlockData = result.data
+            if (data.newBlock) {
+              console.log('Received block data:', data)
+              const accountInfo = await this.getAccountInfo({ publicKey })
+              console.log('Received updated account info:', accountInfo)
+            } else {
+              console.error('No new block data in result:', result)
+            }
+          } else {
+            console.error('Unexpected result:', result)
+          }
+        }
+      })
+  }
+
+  private async getAccountInfo(args: AccountInfoArgs): Promise<AccountInfo> {
+    console.log('Initiating getAccountInfo with args:', args)
+    const query = gql`
+      ${getAccountBalance}
+    `
+    try {
+      console.log('Sending request for account info...')
+      const data = (await this.gqlClient.request(query, {
+        publicKey: args.publicKey
+      })) as AccountData
+      console.log('Received response for account info:', data)
+
+      if (!data || !data.account) {
+        throw new Error('Invalid account data response')
+      }
+      return data.account
+    } catch (error: unknown) {
+      console.error('Error in getAccountInfo:', error)
+      // this can fail if the account doesn't exist yet on the chain & if the node is not available
+      // perform health check to see if the node is available
+      const healthCheckResponse = await this.accountInfoProvider.healthCheck()
+      if (!healthCheckResponse.ok) {
+        throw new Error('Node is not available')
+      }
+      // if the node is available, then the account doesn't exist yet
+      // return an empty account
+      console.log('Error in getAccountInfo, account does not exist yet!')
+      return {
+        balance: { total: 0 },
+        nonce: 0,
+        inferredNonce: 0,
+        delegate: '',
+        publicKey: args.publicKey
+      }
+    }
+  }
+}

--- a/packages/providers/src/mina-node/block-listener/index.ts
+++ b/packages/providers/src/mina-node/block-listener/index.ts
@@ -1,0 +1,1 @@
+export * from './BlockListenerProvider'

--- a/packages/providers/src/mina-node/block-listener/queries.ts
+++ b/packages/providers/src/mina-node/block-listener/queries.ts
@@ -1,0 +1,9 @@
+export const healthCheckQuery = `
+  {
+    __schema {
+      types {
+        name
+      }
+    }
+  }
+`

--- a/packages/providers/src/mina-node/chain-history/chain-history-provider.ts
+++ b/packages/providers/src/mina-node/chain-history/chain-history-provider.ts
@@ -1,0 +1,59 @@
+import {
+  ChainHistoryProvider,
+  Mina,
+  TransactionsByAddressesArgs,
+  TransactionsByIdsArgs
+} from '@palladxyz/mina-core'
+
+import { createGraphQLRequest } from '../utils/fetch-utils'
+import {
+  healthCheck,
+  healthCheckQueryArchive
+} from '../utils/health-check-utils'
+import { transactionsByAddressesQuery } from './queries'
+
+export const createChainHistoryProvider = (
+  url: string
+): ChainHistoryProvider => {
+  const transactionsByAddresses = async (
+    args: TransactionsByAddressesArgs
+  ): Promise<Mina.TransactionBody[]> => {
+    const { startAt, limit } = args.pagination || { startAt: 0, limit: 10 }
+    // TODO: remove array of addresses from TransactionsByAddressesArgs
+    const variables = { address: args.addresses[0], limit, offset: startAt }
+    const query = transactionsByAddressesQuery
+    const fetchGraphQL = createGraphQLRequest(url)
+    const result = await fetchGraphQL(query, variables)
+
+    if (!result.ok) {
+      throw new Error(result.message)
+    }
+
+    const transactions = result.data.transactions
+
+    return transactions
+  }
+
+  const transactionsByHashes = async (
+    args: TransactionsByIdsArgs
+  ): Promise<Mina.TransactionBody[]> => {
+    const variables = { ids: args.ids }
+    const query = transactionsByAddressesQuery
+    const fetchGraphQL = createGraphQLRequest(url)
+    const result = await fetchGraphQL(query, variables)
+
+    if (!result.ok) {
+      throw new Error(result.message)
+    }
+
+    const transactions = result.data
+
+    return transactions
+  }
+
+  return {
+    healthCheck: () => healthCheck(url, healthCheckQueryArchive),
+    transactionsByAddresses,
+    transactionsByHashes
+  }
+}

--- a/packages/providers/src/mina-node/chain-history/index.ts
+++ b/packages/providers/src/mina-node/chain-history/index.ts
@@ -1,0 +1,1 @@
+export * from './chain-history-provider'

--- a/packages/providers/src/mina-node/chain-history/queries.ts
+++ b/packages/providers/src/mina-node/chain-history/queries.ts
@@ -1,0 +1,42 @@
+export const transactionsByAddressesQuery = `
+  query Transactions($address: String!, $limit: Int) {
+    transactions(
+      query: { canonical: true, OR: [{ to: $address }, { from: $address }] }
+      limit: $limit
+      sortBy: DATETIME_DESC
+    ) {
+      amount
+      to
+      token
+      kind
+      isDelegation
+      hash
+      from
+      fee
+      failureReason
+      dateTime
+      blockHeight
+    }
+  }
+`
+
+export const transactionsByHashesQuery = `
+  query Transaction($hash: String!) {
+    transaction(query: { hash: $hash }) {
+      amount
+      blockHeight
+      dateTime
+      failureReason
+      fee
+      from
+      hash
+      id
+      isDelegation
+      kind
+      memo
+      nonce
+      to
+      token
+    }
+  }
+`

--- a/packages/providers/src/mina-node/daemon-status/daemon-status-provider.ts
+++ b/packages/providers/src/mina-node/daemon-status/daemon-status-provider.ts
@@ -1,0 +1,27 @@
+import { DaemonStatus, DaemonStatusProvider } from '@palladxyz/mina-core'
+
+import { createGraphQLRequest } from '../utils/fetch-utils'
+import { healthCheck } from '../utils/health-check-utils'
+import { getDaemonStatusQuery } from './queries'
+
+export const createDaemonStatusProvider = (
+  url: string
+): DaemonStatusProvider => {
+  const getDaemonStatus = async (): Promise<DaemonStatus> => {
+    const fetchGraphQL = createGraphQLRequest(url)
+    const result = await fetchGraphQL(getDaemonStatusQuery)
+
+    if (!result.ok) {
+      throw new Error(result.message)
+    }
+
+    const daemonStatus = result.data
+
+    return daemonStatus
+  }
+
+  return {
+    healthCheck: () => healthCheck(url),
+    getDaemonStatus
+  }
+}

--- a/packages/providers/src/mina-node/daemon-status/index.ts
+++ b/packages/providers/src/mina-node/daemon-status/index.ts
@@ -1,0 +1,1 @@
+export * from './daemon-status-provider'

--- a/packages/providers/src/mina-node/daemon-status/queries.ts
+++ b/packages/providers/src/mina-node/daemon-status/queries.ts
@@ -1,0 +1,7 @@
+export const getDaemonStatusQuery = `
+query {
+  daemonStatus {
+    chainId
+  }
+}
+`

--- a/packages/providers/src/mina-node/index.ts
+++ b/packages/providers/src/mina-node/index.ts
@@ -1,0 +1,5 @@
+export * from './account-info'
+export * from './chain-history'
+export * from './daemon-status'
+export * from './tx-submit'
+export * from './types'

--- a/packages/providers/src/mina-node/tx-submit/index.ts
+++ b/packages/providers/src/mina-node/tx-submit/index.ts
@@ -1,0 +1,1 @@
+export * from './tx-submit-provider'

--- a/packages/providers/src/mina-node/tx-submit/mutations.ts
+++ b/packages/providers/src/mina-node/tx-submit/mutations.ts
@@ -1,0 +1,169 @@
+export function getTxSend(isRawSignature: boolean): string {
+  if (isRawSignature) {
+    return `
+        mutation sendTx($fee:UInt64!, $amount:UInt64!,
+        $to: PublicKey!, $from: PublicKey!, $nonce:UInt32, $memo: String,
+        $validUntil: UInt32, $rawSignature: String!) {
+          sendPayment(
+            input: {
+              fee: $fee,
+              amount: $amount,
+              to: $to,
+              from: $from,
+              memo: $memo,
+              nonce: $nonce,
+              validUntil: $validUntil
+            }, 
+            signature: {rawSignature: $rawSignature}) {
+            payment {
+              __typename
+              id
+              hash
+              kind
+              nonce
+              source {
+                publicKey
+              }
+              receiver {
+                publicKey
+              }
+              feePayer {
+                publicKey
+              }
+              validUntil
+              token
+              amount
+              feeToken
+              fee
+              memo
+            }
+          }
+        }
+      `
+  } else {
+    return `
+        mutation sendTx($fee:UInt64!, $amount:UInt64!,
+        $to: PublicKey!, $from: PublicKey!, $nonce:UInt32, $memo: String,
+        $validUntil: UInt32, $scalar: String!, $field: String!) {
+          sendPayment(
+            input: {
+              fee: $fee,
+              amount: $amount,
+              to: $to,
+              from: $from,
+              memo: $memo,
+              nonce: $nonce,
+              validUntil: $validUntil
+            }, 
+            signature: {field: $field, scalar: $scalar}) {
+            payment {
+              __typename
+              id
+              hash
+              kind
+              nonce
+              source {
+                publicKey
+              }
+              receiver {
+                publicKey
+              }
+              feePayer {
+                publicKey
+              }
+              validUntil
+              token
+              amount
+              feeToken
+              fee
+              memo
+            }
+          }
+        }
+      `
+  }
+}
+
+export function getStakeTxSend(isRawSignature: boolean): string {
+  if (isRawSignature) {
+    return `
+        mutation stakeTx($fee:UInt64!, 
+        $to: PublicKey!, $from: PublicKey!, $nonce:UInt32, $memo: String,
+        $validUntil: UInt32, $rawSignature: String!) {
+          sendDelegation(
+            input: {
+              fee: $fee,
+              to: $to,
+              from: $from,
+              memo: $memo,
+              nonce: $nonce,
+              validUntil: $validUntil
+            }, 
+            signature: {rawSignature: $rawSignature}) {
+            delegation {
+              __typename
+              id
+              hash
+              kind
+              nonce
+              source {
+                publicKey
+              }
+              receiver {
+                publicKey
+              }
+              feePayer {
+                publicKey
+              }
+              validUntil
+              token
+              amount
+              feeToken
+              fee
+              memo
+            }
+          }
+        }
+      `
+  } else {
+    return `
+        mutation stakeTx($fee:UInt64!,
+        $to: PublicKey!, $from: PublicKey!, $nonce:UInt32, $memo: String,
+        $validUntil: UInt32, $scalar: String!, $field: String!) {
+          sendDelegation(
+            input: {
+              fee: $fee,
+              to: $to,
+              from: $from,
+              memo: $memo,
+              nonce: $nonce,
+              validUntil: $validUntil
+            }, 
+            signature: {field: $field, scalar: $scalar}) {
+            delegation {
+              __typename
+              id
+              hash
+              kind
+              nonce
+              source {
+                publicKey
+              }
+              receiver {
+                publicKey
+              }
+              feePayer {
+                publicKey
+              }
+              validUntil
+              token
+              amount
+              feeToken
+              fee
+              memo
+            }
+          }
+        }
+      `
+  }
+}

--- a/packages/providers/src/mina-node/tx-submit/tx-submit-provider.ts
+++ b/packages/providers/src/mina-node/tx-submit/tx-submit-provider.ts
@@ -1,0 +1,47 @@
+import {
+  SubmitTxArgs,
+  SubmitTxResult,
+  TxSubmitProvider
+} from '@palladxyz/mina-core'
+
+import { createGraphQLRequest } from '../utils/fetch-utils'
+import { healthCheck } from '../utils/health-check-utils'
+import { getStakeTxSend, getTxSend } from './mutations'
+
+export const createTxSubmitProvider = (url: string): TxSubmitProvider => {
+  const submitTx = async (args: SubmitTxArgs): Promise<SubmitTxResult> => {
+    const isRawSignature = typeof args.signedTransaction.signature === 'string'
+    let mutation
+    if (args.kind === 'payment') {
+      mutation = `
+            ${getTxSend(isRawSignature)}
+          `
+    } else {
+      mutation = `
+            ${getStakeTxSend(isRawSignature)}
+          `
+    }
+
+    const variables = {
+      ...args.transactionDetails,
+      field: args.signedTransaction.signature.field,
+      scalar: args.signedTransaction.signature.scalar
+    }
+
+    const fetchGraphQL = createGraphQLRequest(url)
+    const result = await fetchGraphQL(mutation, variables)
+
+    if (!result.ok) {
+      throw new Error(result.message)
+    }
+
+    const submissionResult = result.data
+
+    return submissionResult
+  }
+
+  return {
+    healthCheck: () => healthCheck(url),
+    submitTx
+  }
+}

--- a/packages/providers/src/mina-node/types.ts
+++ b/packages/providers/src/mina-node/types.ts
@@ -1,0 +1,62 @@
+import {
+  AccountInfo,
+  AccountInfoArgs,
+  Mina,
+  SubmitTxArgs,
+  SubmitTxResult,
+  TransactionsByAddressesArgs,
+  TransactionsByIdsArgs,
+  TxStatus,
+  TxStatusArgs
+} from '@palladxyz/mina-core'
+/**
+ * An interface that abstracts over Mina node queries.
+ */
+export interface ProviderNode {
+  /**
+   * The provider itself
+   */
+  provider: this
+
+  /**
+   *  Shutdown any resources this provider is using. No additional
+   *  calls should be made to this provider after calling this.
+   */
+  destroy(): void
+
+  // TO DO: add methods that are familiar to ethers.js users
+  // getBalance(address: AddressLike, blockTag?: BlockTag): Promise<bigint>;
+  // getTransactionCount(address: AddressLike, blockTag?: BlockTag): Promise<number>;
+  // getBlock(blockHashOrBlockTag: BlockTag | string, prefetchTxs?: boolean): Promise<null | Block>;
+  // getTransactionResult(hash: string): Promise<null | string>;
+
+  getAccountInfo(args: AccountInfoArgs): Promise<AccountInfo | undefined>
+
+  getTransactionStatus(args: TxStatusArgs): Promise<TxStatus | undefined>
+
+  submitTransaction(args: SubmitTxArgs): Promise<SubmitTxResult | undefined>
+}
+
+/**
+ * An interface that abstracts over Mina Archive node queries.
+ */
+export interface ProviderArchive {
+  /**
+   * The provider itself
+   */
+  provider: this
+
+  /**
+   *  Shutdown any resources this provider is using. No additional
+   *  calls should be made to this provider after calling this.
+   */
+  destroy(): void
+
+  getTransactions(
+    args: TransactionsByAddressesArgs
+  ): Promise<Mina.Paginated<Mina.TransactionBody> | undefined>
+
+  getTransaction(
+    args: TransactionsByIdsArgs
+  ): Promise<Mina.TransactionBody[] | undefined>
+}

--- a/packages/providers/src/mina-node/utils/custom-fetch.ts
+++ b/packages/providers/src/mina-node/utils/custom-fetch.ts
@@ -1,0 +1,18 @@
+import JSONbig from 'json-bigint'
+
+export const customFetch = async (
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> => {
+  const response = await fetch(input, init)
+  const text = await response.text()
+  const parsed = JSONbig.parse(text)
+  return new Response(JSON.stringify(parsed), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: new Headers({
+      'Content-Type': 'application/json',
+      ...response.headers
+    })
+  })
+}

--- a/packages/providers/src/mina-node/utils/error-policy.ts
+++ b/packages/providers/src/mina-node/utils/error-policy.ts
@@ -1,0 +1,1 @@
+export type ErrorPolicy = 'none' | 'ignore' | 'all'

--- a/packages/providers/src/mina-node/utils/errors.ts
+++ b/packages/providers/src/mina-node/utils/errors.ts
@@ -1,0 +1,28 @@
+export interface ExtendedError extends Error {
+  text?: string
+}
+
+export class ServerError extends Error {
+  originalError: Error
+  statusCode: number
+  responseBody?: string | undefined
+
+  constructor(
+    originalError: ExtendedError,
+    statusCode: number,
+    responseBody?: string
+  ) {
+    super(`Server Error: ${statusCode} - ${originalError.message}`)
+    this.name = 'ServerError'
+    this.originalError = originalError
+    this.statusCode = statusCode
+    this.responseBody = responseBody
+
+    // Manually adjust the stack trace to omit the constructor call
+    if (this.stack) {
+      const newStack = this.stack.split('\n')
+      newStack.splice(1, 1) // Remove the constructor call from the stack trace
+      this.stack = newStack.join('\n')
+    }
+  }
+}

--- a/packages/providers/src/mina-node/utils/fetch-utils.ts
+++ b/packages/providers/src/mina-node/utils/fetch-utils.ts
@@ -1,0 +1,37 @@
+import { GraphQLClient } from 'graphql-request'
+
+import { customFetch } from './custom-fetch'
+import { defaultJsonSerializer } from './json-serializer'
+
+type ErrorPolicy = 'ignore' | 'all' // Define more types if needed
+type FetchFunctionType = typeof fetch // Assuming you are using the standard Fetch API
+
+export const createGraphQLRequest = (
+  url: string,
+  errorPolicy: ErrorPolicy = 'ignore',
+  fetchFunction: FetchFunctionType | undefined = undefined
+) => {
+  const graphqlClient = new GraphQLClient(url, {
+    errorPolicy,
+    jsonSerializer: defaultJsonSerializer,
+    fetch: fetchFunction || customFetch
+  })
+
+  const request = async <T = any>(
+    query: string,
+    variables: Record<string, any> = {}
+  ): Promise<{ ok: boolean; data?: T; message?: string }> => {
+    try {
+      const response = await graphqlClient.request<T>(query, variables)
+      return { ok: true, data: response }
+    } catch (error) {
+      console.error('Error during GraphQL request:', error)
+      if (error instanceof Error) {
+        return { ok: false, message: error.message }
+      }
+      return { ok: false, message: 'An unknown error occurred' }
+    }
+  }
+
+  return request
+}

--- a/packages/providers/src/mina-node/utils/health-check-utils.ts
+++ b/packages/providers/src/mina-node/utils/health-check-utils.ts
@@ -1,0 +1,54 @@
+import { createGraphQLRequest } from './fetch-utils'
+
+export const healthCheckQuery = `{ syncStatus }`
+export const healthCheckQueryArchive = `
+  {
+    __schema {
+      types {
+        name
+      }
+    }
+  }
+`
+
+export const healthCheck = async (
+  url: string,
+  query: string = healthCheckQuery
+): Promise<{ ok: boolean; message: string }> => {
+  const request = createGraphQLRequest(url)
+
+  const result = await request(query)
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      message: result.message || 'Health check failed'
+    }
+  }
+
+  // Check for syncStatus response
+  const syncStatus = result.data?.syncStatus
+  if (syncStatus !== undefined) {
+    return {
+      ok: syncStatus === 'SYNCED',
+      message: syncStatus
+        ? `Sync status: ${syncStatus}`
+        : 'No sync status data available'
+    }
+  }
+
+  // Check for __schema response
+  const schemaTypes = result.data?.__schema?.types
+  if (schemaTypes) {
+    return {
+      ok: true,
+      message: 'Schema types available'
+    }
+  }
+
+  // If neither response is found
+  return {
+    ok: false,
+    message: 'Unexpected response format'
+  }
+}

--- a/packages/providers/src/mina-node/utils/index.ts
+++ b/packages/providers/src/mina-node/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './custom-fetch'
+export * from './error-policy'
+export * from './errors'
+export * from './json-serializer'

--- a/packages/providers/src/mina-node/utils/json-serializer.ts
+++ b/packages/providers/src/mina-node/utils/json-serializer.ts
@@ -1,0 +1,3 @@
+import JSONbig from 'json-bigint'
+
+export const defaultJsonSerializer = JSONbig({ useNativeBigInt: true })

--- a/packages/providers/src/unified-providers/account-info-provider.ts
+++ b/packages/providers/src/unified-providers/account-info-provider.ts
@@ -5,7 +5,7 @@ import {
   HealthCheckResponse
 } from '@palladxyz/mina-core'
 
-import { createAccountInfoProvider as me } from '../mina-explorer'
+import { createAccountInfoProvider as mn } from '../mina-node'
 import { createAccountInfoProvider as ob } from '../obscura-provider'
 import { ProviderConfig } from './types'
 
@@ -13,8 +13,8 @@ export const createAccountInfoProvider = (
   config: ProviderConfig
 ): AccountInfoProvider => {
   const underlyingProvider =
-    config.nodeEndpoint.providerName === 'mina-explorer'
-      ? me(config.nodeEndpoint.url)
+    config.nodeEndpoint.providerName === 'mina-node'
+      ? mn(config.nodeEndpoint.url)
       : ob(config.nodeEndpoint.url)
 
   const getAccountInfo = async (

--- a/packages/providers/src/unified-providers/chain-history-provider.ts
+++ b/packages/providers/src/unified-providers/chain-history-provider.ts
@@ -6,7 +6,7 @@ import {
   TransactionsByIdsArgs
 } from '@palladxyz/mina-core'
 
-import { createChainHistoryProvider as me } from '../mina-explorer'
+import { createChainHistoryProvider as mn } from '../mina-node'
 import { createChainHistoryProvider as ob } from '../obscura-provider'
 import { ProviderConfig } from './types'
 
@@ -19,8 +19,8 @@ export const createChainHistoryProvider = (
     )
   }
   const underlyingProvider =
-    config.nodeEndpoint.providerName === 'mina-explorer'
-      ? me(config.archiveNodeEndpoint.url)
+    config.nodeEndpoint.providerName === 'mina-node'
+      ? mn(config.archiveNodeEndpoint.url)
       : ob(config.archiveNodeEndpoint.url)
 
   const transactionsByAddresses = async (

--- a/packages/providers/src/unified-providers/daemon-status-provider.ts
+++ b/packages/providers/src/unified-providers/daemon-status-provider.ts
@@ -4,7 +4,7 @@ import {
   HealthCheckResponse
 } from '@palladxyz/mina-core'
 
-import { createDaemonStatusProvider as me } from '../mina-explorer'
+import { createDaemonStatusProvider as mn } from '../mina-node'
 import { createDaemonStatusProvider as ob } from '../obscura-provider'
 import { ProviderConfig } from './types'
 
@@ -12,8 +12,8 @@ export const createDaemonStatusProvider = (
   config: ProviderConfig
 ): DaemonStatusProvider => {
   const underlyingProvider =
-    config.nodeEndpoint.providerName === 'mina-explorer'
-      ? me(config.nodeEndpoint.url)
+    config.nodeEndpoint.providerName === 'mina-node'
+      ? mn(config.nodeEndpoint.url)
       : ob(config.nodeEndpoint.url)
 
   const getDaemonStatus = async (): Promise<DaemonStatus> => {

--- a/packages/providers/src/unified-providers/tx-submit-provider.ts
+++ b/packages/providers/src/unified-providers/tx-submit-provider.ts
@@ -5,7 +5,7 @@ import {
   TxSubmitProvider
 } from '@palladxyz/mina-core'
 
-import { createTxSubmitProvider as me } from '../mina-explorer'
+import { createTxSubmitProvider as mn } from '../mina-node'
 import { createTxSubmitProvider as ob } from '../obscura-provider'
 import { ProviderConfig } from './types'
 
@@ -13,8 +13,8 @@ export const createTxSubmitProvider = (
   config: ProviderConfig
 ): TxSubmitProvider => {
   const underlyingProvider =
-    config.nodeEndpoint.providerName === 'mina-explorer'
-      ? me(config.nodeEndpoint.url)
+    config.nodeEndpoint.providerName === 'mina-node'
+      ? mn(config.nodeEndpoint.url)
       : ob(config.nodeEndpoint.url)
 
   const submitTx = async (args: SubmitTxArgs): Promise<SubmitTxResult> => {

--- a/packages/providers/src/unified-providers/types.ts
+++ b/packages/providers/src/unified-providers/types.ts
@@ -1,10 +1,10 @@
 export type ProviderConfig = {
   nodeEndpoint: {
-    providerName: 'mina-explorer' | 'obscura'
+    providerName: 'mina-node' | 'obscura'
     url: string
   }
   archiveNodeEndpoint?: {
-    providerName: 'mina-explorer' | 'obscura'
+    providerName: 'mina-node' | 'obscura'
     url: string
   }
   networkName: string

--- a/packages/providers/test/mina-node/mina-explorer/individual-providers/account-info-provider.test.ts
+++ b/packages/providers/test/mina-node/mina-explorer/individual-providers/account-info-provider.test.ts
@@ -1,0 +1,40 @@
+import { TokenIdMap } from '@palladxyz/mina-core'
+
+import { MinaExplorer } from '../../../../src'
+
+const nodeUrl =
+  process.env['NODE_URL'] || 'https://proxy.berkeley.minaexplorer.com/'
+const publicKey =
+  process.env['PUBLIC_KEY'] ||
+  'B62qkAqbeE4h1M5hop288jtVYxK1MsHVMMcBpaWo8qdsAztgXaHH1xq'
+// TODO: change this to local network
+describe.skip('Mina Explorer Account Info Provider (Functional)', () => {
+  let provider: ReturnType<typeof MinaExplorer.createAccountInfoProvider>
+  let tokenMap: TokenIdMap
+
+  beforeEach(() => {
+    provider = MinaExplorer.createAccountInfoProvider(nodeUrl)
+    tokenMap = {
+      MINA: '1'
+    }
+  })
+
+  describe('healthCheck', () => {
+    it('should return a health check response', async () => {
+      // This test depends on the actual response from the server
+      const response = await provider.healthCheck()
+      expect(response.ok).toBe(true)
+    })
+  })
+
+  describe('getAccountInfo', () => {
+    it('should return account info for a valid public key', async () => {
+      // This test now depends on the actual response from the server
+      const response = await provider.getAccountInfo({ publicKey, tokenMap })
+      console.log('Mina Explorer AccountInfo Provider Response', response)
+      expect(response).toHaveProperty('MINA')
+    })
+  })
+
+  //TODO: Other tests...
+})

--- a/packages/providers/test/mina-node/mina-explorer/individual-providers/chain-history-provider.test.ts
+++ b/packages/providers/test/mina-node/mina-explorer/individual-providers/chain-history-provider.test.ts
@@ -1,0 +1,53 @@
+import { Mina } from '@palladxyz/mina-core'
+
+import { MinaExplorer } from '../../../../src'
+
+const nodeUrl =
+  process.env['ARCHIVE_NODE_URL'] || 'https://berkeley.graphql.minaexplorer.com'
+const publicKey =
+  process.env['PUBLIC_KEY'] ||
+  'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb'
+
+describe('Mina Explorer Chain History Provider (Functional)', () => {
+  let provider: ReturnType<typeof MinaExplorer.createChainHistoryProvider>
+
+  beforeEach(() => {
+    provider = MinaExplorer.createChainHistoryProvider(nodeUrl)
+  })
+
+  describe('healthCheck', () => {
+    it('should return a health check response', async () => {
+      // This test depends on the actual response from the server
+      const response = await provider.healthCheck()
+      expect(response.ok).toBe(true)
+    })
+  })
+
+  describe('transactionsByAddresses', () => {
+    it('should return transaction history for a public key', async () => {
+      // This test now depends on the actual response from the server
+      const response = (await provider.transactionsByAddresses({
+        addresses: [publicKey]
+      })) as Mina.TransactionBody[]
+      // TODO: check why pageResults is undefined
+      console.log('Mina Explorer Chain History Provider Response', response)
+      // TODO: investigate pagination
+      const transaction = response[0]
+      console.log('Mina Explorer Chain History Provider Response', transaction)
+
+      expect(transaction).toHaveProperty('amount')
+      expect(transaction).toHaveProperty('blockHeight')
+      expect(transaction).toHaveProperty('dateTime')
+      expect(transaction).toHaveProperty('failureReason')
+      expect(transaction).toHaveProperty('fee')
+      expect(transaction).toHaveProperty('from')
+      expect(transaction).toHaveProperty('hash')
+      expect(transaction).toHaveProperty('isDelegation')
+      expect(transaction).toHaveProperty('kind')
+      expect(transaction).toHaveProperty('to')
+      expect(transaction).toHaveProperty('token')
+    })
+  })
+
+  //TODO: Other tests...
+})

--- a/packages/providers/test/mina-node/mina-explorer/individual-providers/submit-tx-provider.test.ts
+++ b/packages/providers/test/mina-node/mina-explorer/individual-providers/submit-tx-provider.test.ts
@@ -1,0 +1,147 @@
+import {
+  ChainOperationArgs,
+  constructTransaction,
+  FromBip39MnemonicWordsProps,
+  InMemoryKeyAgent,
+  MinaPayload,
+  MinaSpecificArgs,
+  Network
+} from '@palladxyz/key-management'
+import { Mina, TokenIdMap } from '@palladxyz/mina-core'
+import {
+  Payment,
+  SignedLegacy
+} from 'mina-signer/dist/node/mina-signer/src/TSTypes'
+
+import { MinaExplorer } from '../../../../src'
+
+const nodeUrl =
+  process.env['NODE_URL'] || 'https://proxy.berkeley.minaexplorer.com/'
+const publicKey =
+  process.env['PUBLIC_KEY'] ||
+  'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb'
+
+const params = {
+  passphrase: 'passphrase'
+}
+
+const getPassphrase = async () => Buffer.from(params.passphrase)
+// TODO: change this to local network
+// TODO: use different mnemonic for this test -- else there are two duplicate transactions with the unified provider tests
+describe.skip('Mina Explorer Submit Transaction Provider (Functional)', () => {
+  let provider: ReturnType<typeof MinaExplorer.createTxSubmitProvider>
+  let accountInfoProvider: ReturnType<
+    typeof MinaExplorer.createAccountInfoProvider
+  >
+  let tokenMap: TokenIdMap
+  let networkType: Mina.NetworkType
+  let agent: InMemoryKeyAgent
+  let mnemonic: string[]
+
+  beforeEach(() => {
+    provider = MinaExplorer.createTxSubmitProvider(nodeUrl)
+    accountInfoProvider = MinaExplorer.createAccountInfoProvider(nodeUrl)
+    tokenMap = {
+      MINA: '1'
+    }
+  })
+
+  beforeAll(async () => {
+    mnemonic = [
+      'habit',
+      'hope',
+      'tip',
+      'crystal',
+      'because',
+      'grunt',
+      'nation',
+      'idea',
+      'electric',
+      'witness',
+      'alert',
+      'like'
+    ]
+    networkType = 'testnet'
+    const agentArgs: FromBip39MnemonicWordsProps = {
+      getPassphrase: getPassphrase,
+      mnemonicWords: mnemonic,
+      mnemonic2ndFactorPassphrase: ''
+    }
+    agent = await InMemoryKeyAgent.fromMnemonicWords(agentArgs)
+    const args: MinaSpecificArgs = {
+      network: Network.Mina,
+      accountIndex: 0,
+      addressIndex: 0,
+      networkType: networkType
+    }
+    const payload = new MinaPayload()
+
+    await agent.restoreKeyAgent(payload, args, getPassphrase)
+  })
+
+  describe('healthCheck', () => {
+    it('should return a health check response', async () => {
+      // This test depends on the actual response from the server
+      const response = await provider.healthCheck()
+      expect(response.ok).toBe(true)
+    })
+  })
+  // TODO: use different mnemonic for this test -- else there are two duplicate transactions
+  describe.skip('submitTx', () => {
+    it('should return the submitted transaction response', async () => {
+      // fetch account info
+      const accountInfo = await accountInfoProvider.getAccountInfo({
+        publicKey,
+        tokenMap
+      })
+      console.log('Account Info', accountInfo)
+      // construct transaction, sign, and submit
+      const amount = 1 * 1e9
+      const inferredNonce = accountInfo['MINA']?.inferredNonce ?? 0
+      const transaction: Mina.TransactionBody = {
+        to: 'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb',
+        from: 'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb',
+        fee: 1 * 1e9,
+        amount: amount,
+        nonce: Number(inferredNonce),
+        memo: 'test suite',
+        type: 'payment',
+        validUntil: 4294967295
+      }
+      const constructedTx: Mina.ConstructedTransaction = constructTransaction(
+        transaction,
+        Mina.TransactionKind.PAYMENT
+      )
+      const credential = agent.serializableData.credentialSubject.contents[0]
+      const args: ChainOperationArgs = {
+        operation: 'mina_signTransaction',
+        network: 'Mina',
+        networkType: networkType
+      }
+      console.log('Credential', credential)
+      const signedTx = await agent.sign(credential, constructedTx, args)
+      const submitTxArgs = {
+        signedTransaction: signedTx as unknown as SignedLegacy<Payment>, // or SignedLegacy<Common>
+        kind: Mina.TransactionKind.PAYMENT,
+        transactionDetails: {
+          fee: transaction.fee,
+          to: transaction.to,
+          from: transaction.from,
+          nonce: transaction.nonce,
+          memo: transaction.memo,
+          amount: transaction.amount,
+          validUntil: transaction.validUntil
+        }
+      }
+      // This test now depends on the actual response from the server
+      const response = await provider.submitTx(submitTxArgs)
+      console.log(
+        'Mina Explorer Submit Transaction Provider Response',
+        response
+      )
+      //expect(response).toHaveProperty('MINA')
+    })
+  })
+
+  //TODO: Other tests...
+})

--- a/packages/providers/test/mina-node/zeko-sequencer/individual-providers/account-info-provider.test.ts
+++ b/packages/providers/test/mina-node/zeko-sequencer/individual-providers/account-info-provider.test.ts
@@ -1,0 +1,40 @@
+import { TokenIdMap } from '@palladxyz/mina-core'
+
+import { MinaExplorer } from '../../../../src'
+
+const nodeUrl =
+  process.env['NODE_URL'] || 'http://sequencer-zeko-dev.dcspark.io/graphql'
+const publicKey =
+  process.env['PUBLIC_KEY'] ||
+  'B62qoereGLPUg5RWuoTEGu5CSKnN7AAirwwA2h6J1JHH3RF6wbThXmr'
+// TODO: change this to local network
+describe('Zeko Sequencer Account Info Provider (Functional)', () => {
+  let provider: ReturnType<typeof MinaExplorer.createAccountInfoProvider>
+  let tokenMap: TokenIdMap
+
+  beforeEach(() => {
+    provider = MinaExplorer.createAccountInfoProvider(nodeUrl)
+    tokenMap = {
+      MINA: '1'
+    }
+  })
+
+  describe('healthCheck', () => {
+    it('should return a health check response', async () => {
+      // This test depends on the actual response from the server
+      const response = await provider.healthCheck()
+      expect(response.ok).toBe(true)
+    })
+  })
+
+  describe('getAccountInfo', () => {
+    it('should return account info for a valid public key', async () => {
+      // This test now depends on the actual response from the server
+      const response = await provider.getAccountInfo({ publicKey, tokenMap })
+      console.log('Zeko Sequencer AccountInfo Provider Response', response)
+      expect(response).toHaveProperty('MINA')
+    })
+  })
+
+  //TODO: Other tests...
+})

--- a/packages/providers/test/mina-node/zeko-sequencer/individual-providers/submit-tx-provider.test.ts
+++ b/packages/providers/test/mina-node/zeko-sequencer/individual-providers/submit-tx-provider.test.ts
@@ -8,6 +8,7 @@ import {
   Network
 } from '@palladxyz/key-management'
 import { Mina, TokenIdMap } from '@palladxyz/mina-core'
+import Client from 'mina-signer'
 import {
   Payment,
   SignedLegacy
@@ -89,11 +90,14 @@ describe('Zeko Sequencer Submit Transaction Provider (Functional)', () => {
 
   // TODO: use different mnemonic for this test -- else there are two duplicate transactions
   describe('submitTx', () => {
-    /*it('Send Mina on Zeko to Known Account', async () => {
-      const client = new Client({ network: 'testnet' });
+    // this test sends Mina on Zeko Dev Net to a known Pallad address that is used in test suites
+    // if the `submitTx` tests are failing please check if the fee-payer has funds to spend
+    // when there is no fee payer funds please unskip this test to send funds to the known account
+    it.skip('Send Mina on Zeko to Known Account', async () => {
+      const client = new Client({ network: 'testnet' })
       const payment = {
-        to: "B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb",
-        from: "B62qoereGLPUg5RWuoTEGu5CSKnN7AAirwwA2h6J1JHH3RF6wbThXmr",
+        to: 'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb',
+        from: 'B62qoereGLPUg5RWuoTEGu5CSKnN7AAirwwA2h6J1JHH3RF6wbThXmr',
         fee: 2e9,
         nonce: 0
       }
@@ -112,7 +116,7 @@ describe('Zeko Sequencer Submit Transaction Provider (Functional)', () => {
       const signedTx = client.signPayment(
         transaction as Payment,
         'EKDrzVoQTqv6gBrvF81QHYteTYjf4NkzgHbY2JHop4XVH3NbbZWY'
-      );
+      )
 
       const submitTxArgs = {
         signedTransaction: signedTx as unknown as SignedLegacy<Payment>, // or SignedLegacy<Common>
@@ -132,8 +136,7 @@ describe('Zeko Sequencer Submit Transaction Provider (Functional)', () => {
         'Zeko Sequencer Submit Transaction Provider Response',
         response
       )
-
-    })*/
+    })
     it('should return the submitted transaction response', async () => {
       // fetch account info
       const accountInfo = await accountInfoProvider.getAccountInfo({

--- a/packages/providers/test/mina-node/zeko-sequencer/individual-providers/submit-tx-provider.test.ts
+++ b/packages/providers/test/mina-node/zeko-sequencer/individual-providers/submit-tx-provider.test.ts
@@ -1,0 +1,193 @@
+import {
+  ChainOperationArgs,
+  constructTransaction,
+  FromBip39MnemonicWordsProps,
+  InMemoryKeyAgent,
+  MinaPayload,
+  MinaSpecificArgs,
+  Network
+} from '@palladxyz/key-management'
+import { Mina, TokenIdMap } from '@palladxyz/mina-core'
+import {
+  Payment,
+  SignedLegacy
+} from 'mina-signer/dist/node/mina-signer/src/TSTypes'
+
+import { MinaExplorer } from '../../../../src'
+
+const nodeUrl =
+  process.env['NODE_URL'] || 'http://sequencer-zeko-dev.dcspark.io/graphql'
+const publicKey =
+  process.env['PUBLIC_KEY'] ||
+  'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb'
+
+const params = {
+  passphrase: 'passphrase'
+}
+
+const getPassphrase = async () => Buffer.from(params.passphrase)
+// TODO: change this to local network
+// TODO: use different mnemonic for this test -- else there are two duplicate transactions with the unified provider tests
+describe('Zeko Sequencer Submit Transaction Provider (Functional)', () => {
+  let provider: ReturnType<typeof MinaExplorer.createTxSubmitProvider>
+  let accountInfoProvider: ReturnType<
+    typeof MinaExplorer.createAccountInfoProvider
+  >
+  let tokenMap: TokenIdMap
+  let networkType: Mina.NetworkType
+  let agent: InMemoryKeyAgent
+  let mnemonic: string[]
+
+  beforeEach(() => {
+    provider = MinaExplorer.createTxSubmitProvider(nodeUrl)
+    accountInfoProvider = MinaExplorer.createAccountInfoProvider(nodeUrl)
+    tokenMap = {
+      MINA: '1'
+    }
+  })
+
+  beforeAll(async () => {
+    mnemonic = [
+      'habit',
+      'hope',
+      'tip',
+      'crystal',
+      'because',
+      'grunt',
+      'nation',
+      'idea',
+      'electric',
+      'witness',
+      'alert',
+      'like'
+    ]
+    networkType = 'testnet'
+    const agentArgs: FromBip39MnemonicWordsProps = {
+      getPassphrase: getPassphrase,
+      mnemonicWords: mnemonic,
+      mnemonic2ndFactorPassphrase: ''
+    }
+    agent = await InMemoryKeyAgent.fromMnemonicWords(agentArgs)
+    const args: MinaSpecificArgs = {
+      network: Network.Mina,
+      accountIndex: 0,
+      addressIndex: 0,
+      networkType: networkType
+    }
+    const payload = new MinaPayload()
+
+    await agent.restoreKeyAgent(payload, args, getPassphrase)
+  })
+
+  describe('healthCheck', () => {
+    it('should return a health check response', async () => {
+      // This test depends on the actual response from the server
+      const response = await provider.healthCheck()
+      expect(response.ok).toBe(true)
+    })
+  })
+
+  // TODO: use different mnemonic for this test -- else there are two duplicate transactions
+  describe('submitTx', () => {
+    /*it('Send Mina on Zeko to Known Account', async () => {
+      const client = new Client({ network: 'testnet' });
+      const payment = {
+        to: "B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb",
+        from: "B62qoereGLPUg5RWuoTEGu5CSKnN7AAirwwA2h6J1JHH3RF6wbThXmr",
+        fee: 2e9,
+        nonce: 0
+      }
+
+      const transaction: Mina.TransactionBody = {
+        to: payment.to,
+        from: payment.from,
+        fee: 1 * 1e9,
+        amount: 990_000_000_000,
+        nonce: Number(0),
+        memo: 'test suite',
+        type: 'payment',
+        validUntil: 4294967295
+      }
+
+      const signedTx = client.signPayment(
+        transaction as Payment,
+        'EKDrzVoQTqv6gBrvF81QHYteTYjf4NkzgHbY2JHop4XVH3NbbZWY'
+      );
+
+      const submitTxArgs = {
+        signedTransaction: signedTx as unknown as SignedLegacy<Payment>, // or SignedLegacy<Common>
+        kind: Mina.TransactionKind.PAYMENT,
+        transactionDetails: {
+          fee: transaction.fee,
+          to: transaction.to,
+          from: transaction.from,
+          nonce: transaction.nonce,
+          memo: transaction.memo,
+          amount: transaction.amount,
+          validUntil: transaction.validUntil
+        }
+      }
+      const response = await provider.submitTx(submitTxArgs)
+      console.log(
+        'Zeko Sequencer Submit Transaction Provider Response',
+        response
+      )
+
+    })*/
+    it('should return the submitted transaction response', async () => {
+      // fetch account info
+      const accountInfo = await accountInfoProvider.getAccountInfo({
+        publicKey,
+        tokenMap
+      })
+      console.log('Account Info', accountInfo)
+      // construct transaction, sign, and submit
+      const amount = 1 * 1e9
+      const inferredNonce = accountInfo['MINA']?.inferredNonce ?? 0
+      const transaction: Mina.TransactionBody = {
+        to: 'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb',
+        from: 'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb',
+        fee: 0.5 * 1e9,
+        amount: amount,
+        nonce: Number(inferredNonce),
+        memo: 'pallad test suite',
+        type: 'payment',
+        validUntil: 4294967295
+      }
+      const constructedTx: Mina.ConstructedTransaction = constructTransaction(
+        transaction,
+        Mina.TransactionKind.PAYMENT
+      )
+      const credential = agent.serializableData.credentialSubject.contents[0]
+      const args: ChainOperationArgs = {
+        operation: 'mina_signTransaction',
+        network: 'Mina',
+        networkType: networkType
+      }
+      console.log('Credential', credential)
+      const signedTx = await agent.sign(credential, constructedTx, args)
+      const submitTxArgs = {
+        signedTransaction: signedTx as unknown as SignedLegacy<Payment>, // or SignedLegacy<Common>
+        kind: Mina.TransactionKind.PAYMENT,
+        transactionDetails: {
+          fee: transaction.fee,
+          to: transaction.to,
+          from: transaction.from,
+          nonce: transaction.nonce,
+          memo: transaction.memo,
+          amount: transaction.amount,
+          validUntil: transaction.validUntil
+        }
+      }
+      // This test now depends on the actual response from the server
+      const response = await provider.submitTx(submitTxArgs)
+      console.log(
+        'Zeko Sequencer Submit Transaction Provider Response',
+        response
+      )
+      //expect(response).toHaveProperty('MINA')
+    })
+  })
+
+  //TODO: Other tests...
+})

--- a/packages/providers/test/mina-node/zeko-sequencer/individual-providers/util.ts
+++ b/packages/providers/test/mina-node/zeko-sequencer/individual-providers/util.ts
@@ -1,0 +1,54 @@
+import { Mina } from '@palladxyz/mina-core'
+import Client from 'mina-signer'
+import {
+  Payment,
+  SignedLegacy
+} from 'mina-signer/dist/node/mina-signer/src/TSTypes'
+
+import { MinaNode } from '../../../../src'
+
+// this util sends Mina on Zeko Dev Net to a known Pallad address that is used in test suites
+// if the `submitTx` tests are failing please check if the fee-payer has funds to spend
+// when there is no fee payer funds please unskip this test to send funds to the known account
+export async function sendMinaOnZeko(nodeUrl: string): Promise<void> {
+  const provider = MinaNode.createTxSubmitProvider(nodeUrl)
+  const client = new Client({ network: 'testnet' })
+  const payment = {
+    to: 'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb',
+    from: 'B62qoereGLPUg5RWuoTEGu5CSKnN7AAirwwA2h6J1JHH3RF6wbThXmr',
+    fee: 2e9,
+    nonce: 0
+  }
+
+  const transaction: Mina.TransactionBody = {
+    to: payment.to,
+    from: payment.from,
+    fee: 1 * 1e9,
+    amount: 990_000_000_000,
+    nonce: Number(0),
+    memo: 'test suite',
+    type: 'payment',
+    validUntil: 4294967295
+  }
+
+  const signedTx = client.signPayment(
+    transaction as Payment,
+    'EKDrzVoQTqv6gBrvF81QHYteTYjf4NkzgHbY2JHop4XVH3NbbZWY'
+  )
+
+  const submitTxArgs = {
+    signedTransaction: signedTx as unknown as SignedLegacy<Payment>, // or SignedLegacy<Common>
+    kind: Mina.TransactionKind.PAYMENT,
+    transactionDetails: {
+      fee: transaction.fee,
+      to: transaction.to,
+      from: transaction.from,
+      nonce: transaction.nonce,
+      memo: transaction.memo,
+      amount: transaction.amount,
+      validUntil: transaction.validUntil
+    }
+  }
+  const response = await provider.submitTx(submitTxArgs)
+  console.log('Zeko Sequencer Submit Transaction Provider Response', response)
+}

--- a/packages/providers/test/unified-providers/individual-providers/chain-history-provider.test.ts
+++ b/packages/providers/test/unified-providers/individual-providers/chain-history-provider.test.ts
@@ -17,11 +17,11 @@ describe('Unified Chain History Provider (Functional)', () => {
     beforeEach(() => {
       configMinaExplorer = {
         nodeEndpoint: {
-          providerName: 'mina-explorer',
+          providerName: 'mina-node',
           url: '...'
         },
         archiveNodeEndpoint: {
-          providerName: 'mina-explorer',
+          providerName: 'mina-node',
           url: minaExplorerUrl
         },
         networkName: 'berkeley',

--- a/packages/vault/src/network-info/default.ts
+++ b/packages/vault/src/network-info/default.ts
@@ -11,10 +11,18 @@ export const DEFAULT_NETWORK_INFO: Record<NetworkName, ProviderConfig> = {
       url: 'https://mina-berkeley.obscura.build/v1/bfce6350-4f7a-4b63-be9b-8981dec92050/graphql'
     },
     archiveNodeEndpoint: {
-      providerName: 'mina-explorer',
+      providerName: 'mina-node',
       url: 'https://berkeley.graphql.minaexplorer.com'
     },
     networkName: 'Berkeley',
+    chainId: '...' // todo: fetch chainId from a provider
+  },
+  ZekoDevNet: {
+    nodeEndpoint: {
+      providerName: 'mina-node',
+      url: 'http://sequencer-zeko-dev.dcspark.io/graphql'
+    },
+    networkName: 'Zeko Devnet',
     chainId: '...' // todo: fetch chainId from a provider
   }
 }

--- a/packages/vault/src/vault/vaultStore.ts
+++ b/packages/vault/src/vault/vaultStore.ts
@@ -144,6 +144,8 @@ export const useVault = create<
         // TODO: remove providerManager
         //_syncTransactions: async (providerConfig, publicKey) => {
         const { setTransactions } = get()
+        // TODO: add condition where archive node is unavailable then transactions
+        // are simply []
         const provider = createMinaProvider(providerConfig)
         const transactions = await provider.getTransactions({
           addresses: [publicKey]

--- a/packages/vault/test/network-info/network-info-store.test.ts
+++ b/packages/vault/test/network-info/network-info-store.test.ts
@@ -80,7 +80,7 @@ describe('CredentialStore', () => {
 
     // check total number of networks
     const networks = result.current.allNetworkInfo()
-    expect(networks.length).toEqual(3)
+    expect(networks.length).toEqual(4)
   })
   it('should add two networks and set mainnet as current network', async () => {
     const { result } = renderHook(() => useVault())
@@ -100,6 +100,6 @@ describe('CredentialStore', () => {
     })
     const chainIds = result.current.getChainIds()
     console.log('chainIds: ', chainIds)
-    expect(chainIds.length).toEqual(3)
+    expect(chainIds.length).toEqual(4)
   })
 })


### PR DESCRIPTION
## Describe changes
Starting the Zeko integration. Changing provider naming to check readiness of codebase to allow switching from Mina L1 to Zeko L2. 

Changes include new set of tests for Zeko with account information and also submission of transaction. Also adding to this a new package in `providers` called `mina-node` because existing one is fixed to `mina-explorer`.

🚀 🦋 
