### PR TITLE
Feat: Optimism Providers

### DIFF
--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -18,9 +18,9 @@
     "cleanup": "rimraf node_modules dist .turbo"
   },
   "dependencies": {
+    "@palladxyz/key-management": "^0.0.1",
     "@palladxyz/mina-core": "^0.0.1",
     "@palladxyz/util": "^0.0.1",
-    "@palladxyz/key-management": "^0.0.1",
     "bs58check": "^3.0.1",
     "buffer": "^6.0.3",
     "events": "^3.3.0",
@@ -29,6 +29,7 @@
     "json-bigint": "^1.0.0",
     "mina-signer": "^2.1.1",
     "subscriptions-transport-ws": "^0.11.0",
+    "viem": "^2.9.4",
     "ws": "^8.15.1"
   },
   "devDependencies": {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,4 +1,5 @@
 export * as MinaExplorer from './mina-explorer'
 export * as MinaNode from './mina-node'
 export * as Obscura from './obscura-provider'
+export * as Optimism from './optimism'
 export * from './unified-providers'

--- a/packages/providers/src/optimism/account-info/account-info-provider.ts
+++ b/packages/providers/src/optimism/account-info/account-info-provider.ts
@@ -59,7 +59,7 @@ export const createAccountInfoProvider = (url: string): AccountInfoProvider => {
   }
 
   return {
-    healthCheck: () => healthCheckOptimism(), //healthCheck(url),
+    healthCheck: () => healthCheckOptimism(url),
     getAccountInfo
   }
 }

--- a/packages/providers/src/optimism/account-info/account-info-provider.ts
+++ b/packages/providers/src/optimism/account-info/account-info-provider.ts
@@ -1,0 +1,65 @@
+import {
+  AccountInfo,
+  AccountInfoArgs,
+  AccountInfoProvider
+} from '@palladxyz/mina-core'
+import {
+  Address,
+  createPublicClient,
+  formatEther,
+  GetBalanceParameters,
+  GetTransactionCountParameters,
+  http
+} from 'viem'
+import { optimismSepolia } from 'viem/chains'
+
+import { healthCheckOptimism } from '../utils'
+
+export const createAccountInfoProvider = (url: string): AccountInfoProvider => {
+  const getAccountInfo = async (
+    args: AccountInfoArgs
+  ): Promise<Record<string, AccountInfo>> => {
+    const client = createPublicClient({
+      chain: optimismSepolia,
+      transport: http(url)
+    })
+
+    const balanceVariables: GetBalanceParameters = {
+      address: args.publicKey as Address
+    }
+    const balanceETH = await client.getBalance(balanceVariables)
+    const formattedBalance = await formatEther(balanceETH)
+    const nonceVariables: GetTransactionCountParameters = {
+      address: args.publicKey as Address
+    }
+    const nonce = await client.getTransactionCount(nonceVariables)
+
+    console.log('The balance in ETH is', balanceETH)
+
+    const accountsInfo: Record<string, AccountInfo> = {}
+
+    if (balanceETH === null) {
+      accountsInfo['ETH'] = {
+        balance: { total: 0 },
+        inferredNonce: 0,
+        nonce: 0,
+        delegate: '',
+        publicKey: args.publicKey
+      }
+    } else {
+      accountsInfo['ETH'] = {
+        balance: { total: Number(formattedBalance) },
+        inferredNonce: nonce,
+        nonce: nonce,
+        delegate: '',
+        publicKey: args.publicKey
+      }
+    }
+    return accountsInfo
+  }
+
+  return {
+    healthCheck: () => healthCheckOptimism(), //healthCheck(url),
+    getAccountInfo
+  }
+}

--- a/packages/providers/src/optimism/account-info/index.ts
+++ b/packages/providers/src/optimism/account-info/index.ts
@@ -1,0 +1,1 @@
+export * from './account-info-provider'

--- a/packages/providers/src/optimism/chain-history/chain-history-provide.ts
+++ b/packages/providers/src/optimism/chain-history/chain-history-provide.ts
@@ -1,0 +1,45 @@
+import {
+  ChainHistoryProvider,
+  Mina,
+  TransactionsByAddressesArgs,
+  TransactionsByIdsArgs
+} from '@palladxyz/mina-core'
+import { createPublicClient, GetTransactionParameters, Hash, http } from 'viem'
+import { optimismSepolia } from 'viem/chains'
+
+import { healthCheckOptimism } from '../utils'
+
+export const createChainHistoryProvider = (
+  url: string
+): ChainHistoryProvider => {
+  const transactionsByAddresses = async (
+    args: TransactionsByAddressesArgs
+  ): Promise<Mina.TransactionBody[]> => {
+    // need an explorer or other third-party API to fetch transaction history
+    console.log('the args are:', args)
+
+    return []
+  }
+
+  // TODO: decouple Mina from these providers, maybe `@palladxyz/otpimism-core` ?
+  const transactionsByHashes = async (
+    args: TransactionsByIdsArgs
+  ): Promise<Mina.TransactionBody[]> => {
+    const client = createPublicClient({
+      chain: optimismSepolia,
+      transport: http(url)
+    })
+    const transactionArgs: GetTransactionParameters = {
+      hash: args.ids[0] as Hash
+    }
+    const transactions = await client.getTransaction(transactionArgs)
+
+    return transactions as any
+  }
+
+  return {
+    healthCheck: () => healthCheckOptimism(url),
+    transactionsByAddresses,
+    transactionsByHashes
+  }
+}

--- a/packages/providers/src/optimism/chain-history/index.ts
+++ b/packages/providers/src/optimism/chain-history/index.ts
@@ -1,0 +1,1 @@
+export * from './chain-history-provide'

--- a/packages/providers/src/optimism/index.ts
+++ b/packages/providers/src/optimism/index.ts
@@ -1,0 +1,1 @@
+export * from './account-info'

--- a/packages/providers/src/optimism/index.ts
+++ b/packages/providers/src/optimism/index.ts
@@ -1,1 +1,2 @@
 export * from './account-info'
+export * from './chain-history'

--- a/packages/providers/src/optimism/utils/health-check-utils.ts
+++ b/packages/providers/src/optimism/utils/health-check-utils.ts
@@ -1,0 +1,49 @@
+export const healthCheckOptimism = async (): Promise<{
+  ok: boolean
+  message: string
+}> => {
+  return { ok: true, message: 'all good!' }
+}
+/*
+  export const healthCheckOptimism = async (
+    url: string,
+  ): Promise<{ ok: boolean; message: string }> => {
+      const client = createPublicClient({ 
+        chain: optimismGoerli, 
+        transport: http(url), 
+        }) 
+      
+  
+    if (!result.ok) {
+      return {
+        ok: false,
+        message: result.message || 'Health check failed'
+      }
+    }
+  
+    // Check for syncStatus response
+    const syncStatus = result.data?.syncStatus
+    if (syncStatus !== undefined) {
+      return {
+        ok: syncStatus === 'SYNCED',
+        message: syncStatus
+          ? `Sync status: ${syncStatus}`
+          : 'No sync status data available'
+      }
+    }
+  
+    // Check for __schema response
+    const schemaTypes = result.data?.__schema?.types
+    if (schemaTypes) {
+      return {
+        ok: true,
+        message: 'Schema types available'
+      }
+    }
+  
+    // If neither response is found
+    return {
+      ok: false,
+      message: 'Unexpected response format'
+    }
+  }*/

--- a/packages/providers/src/optimism/utils/health-check-utils.ts
+++ b/packages/providers/src/optimism/utils/health-check-utils.ts
@@ -1,49 +1,32 @@
-export const healthCheckOptimism = async (): Promise<{
-  ok: boolean
-  message: string
-}> => {
-  return { ok: true, message: 'all good!' }
-}
-/*
-  export const healthCheckOptimism = async (
-    url: string,
-  ): Promise<{ ok: boolean; message: string }> => {
-      const client = createPublicClient({ 
-        chain: optimismGoerli, 
-        transport: http(url), 
-        }) 
-      
-  
-    if (!result.ok) {
-      return {
-        ok: false,
-        message: result.message || 'Health check failed'
-      }
-    }
-  
-    // Check for syncStatus response
-    const syncStatus = result.data?.syncStatus
-    if (syncStatus !== undefined) {
-      return {
-        ok: syncStatus === 'SYNCED',
-        message: syncStatus
-          ? `Sync status: ${syncStatus}`
-          : 'No sync status data available'
-      }
-    }
-  
-    // Check for __schema response
-    const schemaTypes = result.data?.__schema?.types
-    if (schemaTypes) {
-      return {
-        ok: true,
-        message: 'Schema types available'
-      }
-    }
-  
-    // If neither response is found
+import { createPublicClient, http } from 'viem'
+import { optimismSepolia } from 'viem/chains'
+
+export const healthCheckOptimism = async (
+  url: string
+): Promise<{ ok: boolean; message: string }> => {
+  const client = createPublicClient({
+    chain: optimismSepolia,
+    transport: http(url)
+  })
+
+  const result = await client.getChainId()
+
+  if (!result) {
     return {
       ok: false,
-      message: 'Unexpected response format'
+      message: 'Health check failed'
     }
-  }*/
+  }
+
+  if (result) {
+    return {
+      ok: true,
+      message: 'RPC is happy!'
+    }
+  }
+
+  return {
+    ok: false,
+    message: 'Unexpected response format'
+  }
+}

--- a/packages/providers/src/optimism/utils/index.ts
+++ b/packages/providers/src/optimism/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './health-check-utils'

--- a/packages/providers/test/optimism/account-info-provider.test.ts
+++ b/packages/providers/test/optimism/account-info-provider.test.ts
@@ -1,0 +1,36 @@
+import { TokenIdMap } from '@palladxyz/mina-core'
+
+import { Optimism } from '../../src'
+
+const nodeUrl = process.env['NODE_URL'] || 'https://sepolia.optimism.io'
+const publicKey =
+  process.env['PUBLIC_KEY'] || '0xA98005e6ce8E62ADf8f9020fa99888E8f107e3C9'
+
+// TODO: change this to local network
+describe('Optimism Account Info Provider (Functional)', () => {
+  let provider: ReturnType<typeof Optimism.createAccountInfoProvider>
+  let tokenMap: TokenIdMap
+
+  beforeEach(() => {
+    provider = Optimism.createAccountInfoProvider(nodeUrl)
+  })
+
+  describe('healthCheck', () => {
+    it('should return a health check response', async () => {
+      // This test depends on the actual response from the server
+      const response = await provider.healthCheck()
+      expect(response.ok).toBe(true)
+    })
+  })
+
+  describe('getAccountInfo', () => {
+    it('should return account info for a valid public key', async () => {
+      // This test now depends on the actual response from the server
+      const response = await provider.getAccountInfo({ publicKey, tokenMap })
+      console.log('Optimism AccountInfo Provider Response', response)
+      expect(response).toHaveProperty('ETH')
+    })
+  })
+
+  //TODO: Other tests...
+})

--- a/packages/providers/test/optimism/chain-history-provider.test.ts
+++ b/packages/providers/test/optimism/chain-history-provider.test.ts
@@ -1,0 +1,38 @@
+import { Optimism } from '../../src'
+
+const nodeUrl = process.env['ARCHIVE_NODE_URL'] || 'https://sepolia.optimism.io'
+const transactionHash =
+  process.env['TX_HASH'] ||
+  '0x105bf755a57f5f1e70784dd2ce811795e44a443608879e499d459098fb80f560'
+
+describe('Optimism Chain History Provider (Functional)', () => {
+  let provider: ReturnType<typeof Optimism.createChainHistoryProvider>
+
+  beforeEach(() => {
+    provider = Optimism.createChainHistoryProvider(nodeUrl)
+  })
+
+  describe('healthCheck', () => {
+    it('should return a health check response', async () => {
+      // This test depends on the actual response from the server
+      const response = await provider.healthCheck()
+      expect(response.ok).toBe(true)
+    })
+  })
+
+  describe('transactions receipt', () => {
+    it('should return transaction receipt for a transaction hash', async () => {
+      // This test now depends on the actual response from the server
+      const response = await provider.transactionsByHashes({
+        ids: [transactionHash]
+      })
+
+      console.log('Optimism Chain History Provider Response', response)
+
+      expect(response).toHaveProperty('blockNumber')
+      expect(response).toHaveProperty('blockHash')
+    })
+  })
+
+  //TODO: Other tests...
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,9 @@ importers:
       subscriptions-transport-ws:
         specifier: ^0.11.0
         version: 0.11.0(graphql@16.8.1)
+      viem:
+        specifier: ^2.9.4
+        version: 2.9.4(typescript@5.3.3)
       ws:
         specifier: ^8.15.1
         version: 8.16.0
@@ -5034,6 +5037,14 @@ packages:
       '@scure/base': 1.1.5
     dev: false
 
+  /@scure/bip32@1.3.2:
+    resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
+    dependencies:
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.3
+      '@scure/base': 1.1.5
+    dev: false
+
   /@scure/bip32@1.3.3:
     resolution: {integrity: sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==}
     dependencies:
@@ -6156,6 +6167,20 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /abitype@1.0.0(typescript@5.3.3):
+    resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.3.3
+    dev: false
 
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -10451,6 +10476,14 @@ packages:
   /isomorphic-timers-promises@1.0.1:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
     engines: {node: '>=10'}
+
+  /isows@1.0.3(ws@8.13.0):
+    resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.13.0
+    dev: false
 
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -15193,6 +15226,29 @@ packages:
       d3-timer: 3.0.1
     dev: false
 
+  /viem@2.9.4(typescript@5.3.3):
+    resolution: {integrity: sha512-j239PwRYc9WU7GOogfJ5Iu/5jwYaidpR85gLxKCwQmuXkNILKiRHntEM15EAtC9bcgaa9oklYwQ+/MlLU593/A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
+      abitype: 1.0.0(typescript@5.3.3)
+      isows: 1.0.3(ws@8.13.0)
+      typescript: 5.3.3
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: false
+
   /vite-node@0.34.6(@types/node@20.10.6):
     resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
     engines: {node: '>=v14.18.0'}
@@ -15814,7 +15870,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: true
 
   /ws@8.16.0:
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}


### PR DESCRIPTION
## Describe changes
Pallad already has Ethereum key derivation. Why not add Optimism support to start. 

First I am adding an example account information provider with Optimism's Sepolia testnet to investigate how easy this is. It is only a new sub-package in the `@palladxyz/provider` package for `optimism` using `viem` with the same address in the key package tests.

Next I will look at the chain historical provider.

@mrcnk what do you think?