### PR TITLE
chore: add more significant test coverage in key-management

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -13,6 +13,11 @@ export const baseVitestConfig = {
     environment: 'happy-dom',
     globals: true,
     testTimeout: 100000,
-    hookTimeout: 100000
+    hookTimeout: 100000,
+    test: {
+      coverage: {
+        reporter: ['text', 'json', 'html']
+      }
+    }
   }
 }

--- a/packages/key-management/package.json
+++ b/packages/key-management/package.json
@@ -15,6 +15,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test:unit": "vitest run",
+    "coverage": "vitest run --coverage",
     "cleanup": "rimraf node_modules dist .turbo"
   },
   "dependencies": {
@@ -40,6 +41,7 @@
     "@palladxyz/common": "workspace:*",
     "@types/mocha": "^10.0.6",
     "@types/secp256k1": "^4.0.6",
-    "@types/sinon": "^17.0.2"
+    "@types/sinon": "^17.0.2",
+    "@vitest/coverage-v8": "^1.5.0"
   }
 }

--- a/packages/key-management/src/KeyDecryptor.ts
+++ b/packages/key-management/src/KeyDecryptor.ts
@@ -1,5 +1,3 @@
-// KeyDecryptor.ts
-
 import { emip3decrypt } from './emip3'
 import * as errors from './errors'
 import { getPassphraseRethrowTypedError } from './InMemoryKeyAgent'
@@ -10,10 +8,10 @@ import {
 } from './types'
 
 export class KeyDecryptor {
-  private getPassphrase: (noCache?: true) => Promise<Uint8Array>
+  #getPassphrase: (noCache?: true) => Promise<Uint8Array>
 
   constructor(getPassphrase: GetPassphrase) {
-    this.getPassphrase = getPassphrase
+    this.#getPassphrase = getPassphrase
   }
 
   async decryptChildPrivateKey(
@@ -21,7 +19,7 @@ export class KeyDecryptor {
     noCache?: true
   ): Promise<Uint8Array> {
     const passphrase = await getPassphraseRethrowTypedError(() =>
-      this.getPassphrase(noCache)
+      this.#getPassphrase(noCache)
     )
     let decryptedKeyBytes: Uint8Array
     try {
@@ -54,7 +52,7 @@ export class KeyDecryptor {
     noCache?: true
   ) {
     const passphrase = await getPassphraseRethrowTypedError(() =>
-      this.getPassphrase(noCache)
+      this.#getPassphrase(noCache)
     )
     let decryptedKeyBytes: Uint8Array
     try {

--- a/packages/key-management/src/chains/Ethereum/credentialDerivation.ts
+++ b/packages/key-management/src/chains/Ethereum/credentialDerivation.ts
@@ -2,11 +2,7 @@ import { bytesToHex } from '@noble/hashes/utils'
 import * as secp256k1 from '@noble/secp256k1'
 import { Address } from 'micro-eth-signer'
 
-import {
-  EthereumDerivationArgs,
-  EthereumGroupedCredentials,
-  EthereumSpecificArgs
-} from './types'
+import { EthereumDerivationArgs, EthereumGroupedCredentials } from './types'
 
 export function deriveEthereumPublicAddress(
   privateKey: Uint8Array | string
@@ -41,7 +37,7 @@ export function deriveEthereumPublicKey(privateKey: Uint8Array): string {
 }
 
 export function deriveEthereumCredentials(
-  args: EthereumSpecificArgs | EthereumDerivationArgs,
+  args: EthereumDerivationArgs,
   publicCredential: string,
   encryptedPrivateKeyBytes: Uint8Array
 ): EthereumGroupedCredentials {
@@ -62,7 +58,7 @@ export function deriveEthereumCredentials(
 
 export function isEthereumCredential(
   credential: EthereumGroupedCredentials,
-  args: EthereumSpecificArgs
+  args: EthereumDerivationArgs
 ): boolean {
   // Check if the credential matches the payload
   return (

--- a/packages/key-management/src/chains/Ethereum/keyDerivationUtils.ts
+++ b/packages/key-management/src/chains/Ethereum/keyDerivationUtils.ts
@@ -1,4 +1,5 @@
-import { Network } from '../../types'
+import { Network } from '@palladxyz/pallad-core'
+
 import { EthereumDerivationArgs } from './types'
 
 export function isEthereumDerivation(args: EthereumDerivationArgs): boolean {

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -164,9 +164,9 @@ export interface KeyAgent {
     pure?: boolean
   ): Promise<GroupedCredentials>
 
-  exportRootPrivateKey(): Promise<Uint8Array>
+  exportRootPrivateKey(getPassphrase: GetPassphrase): Promise<Uint8Array>
 
-  decryptSeed(): Promise<Uint8Array>
+  decryptSeed(getPassphrase: GetPassphrase): Promise<Uint8Array>
 }
 
 export type ChainDerivationArgs = MinaDerivationArgs | EthereumDerivationArgs

--- a/packages/key-management/test/ethereum/credential-derivation.test.ts
+++ b/packages/key-management/test/ethereum/credential-derivation.test.ts
@@ -1,0 +1,179 @@
+import { Network } from '@palladxyz/pallad-core'
+import { describe, expect, it } from 'vitest'
+
+import { EthereumDerivationArgs, EthereumGroupedCredentials } from '../../src'
+import {
+  assertIsBytes,
+  deriveEthereumCredentials,
+  deriveEthereumPublicAddress,
+  deriveEthereumPublicKey,
+  isEthereumCredential,
+  privateToPublic
+} from '../../src/chains/Ethereum/credentialDerivation'
+import { isMessage, isTransaction } from '../../src/chains/Ethereum/guards'
+import { isEthereumDerivation } from '../../src/chains/Ethereum/keyDerivationUtils'
+
+describe('credentialderivation utils', () => {
+  const validPrivateKeyHex =
+    'ab8e7c879d7a802940c7a6535752ee6d3064f7dcbb25b4d2cd90c1f8efdb61f0'
+  const validPrivateKeyBytes = Uint8Array.from(
+    Buffer.from(validPrivateKeyHex, 'hex')
+  )
+  const expectedPublicKey = '0xA98005e6ce8E62ADf8f9020fa99888E8f107e3C9'
+
+  const expectedGroupedCredentials: EthereumGroupedCredentials = {
+    '@context': ['https://w3id.org/wallet/v1'],
+    id: 'did:ethr:0xA98005e6ce8E62ADf8f9020fa99888E8f107e3C9',
+    type: 'EthereumAddress',
+    controller: 'did:ethr:0xA98005e6ce8E62ADf8f9020fa99888E8f107e3C9',
+    name: 'Ethereum Account',
+    description: 'My Ethereum account.',
+    chain: Network.Ethereum,
+    accountIndex: 0,
+    addressIndex: 0,
+    address: expectedPublicKey,
+    encryptedPrivateKeyBytes: new Uint8Array([0, 1, 2, 3, 4])
+  }
+
+  it('deriveEthereumPublicAddress should derive the correct public address', () => {
+    const address = deriveEthereumPublicAddress(validPrivateKeyBytes)
+    expect(address).toBeTypeOf('string')
+    expect(address).toHaveLength(42) // Ethereum addresses are 42 characters long including the '0x'
+  })
+
+  it('assertIsBytes should not throw for valid Uint8Array', () => {
+    expect(() => assertIsBytes(validPrivateKeyBytes)).not.toThrow()
+  })
+
+  it('assertIsBytes should throw an error for invalid inputs', () => {
+    const invalidInput = [1, 2, 3] // Not a Uint8Array
+    expect(() => assertIsBytes(invalidInput as any)).toThrow(
+      'This method only supports Uint8Array but input was:'
+    )
+  })
+
+  it('privateToPublic should derive the public key bytes correctly', () => {
+    const publicKey = privateToPublic(validPrivateKeyBytes)
+    expect(publicKey).toBeInstanceOf(Uint8Array)
+    expect(publicKey).toHaveLength(64) // Should return 64 bytes
+  })
+
+  it('deriveEthereumPublicKey should derive the correct hex public key', () => {
+    const publicKeyHex = deriveEthereumPublicKey(validPrivateKeyBytes)
+    expect(publicKeyHex).toBeTypeOf('string')
+    expect(publicKeyHex).toHaveLength(128) // Should be 128 hex characters long
+  })
+
+  it('deriveEthereumCredentials should correctly format Ethereum credentials', () => {
+    const args: EthereumDerivationArgs = {
+      network: Network.Ethereum,
+      addressIndex: 0,
+      accountIndex: 0
+    }
+    const encryptedPrivateKeyBytes = Uint8Array.from([0, 1, 2, 3, 4])
+
+    const credentials = deriveEthereumCredentials(
+      args,
+      expectedPublicKey,
+      encryptedPrivateKeyBytes
+    )
+    expect(credentials).toMatchObject({
+      id: 'did:ethr:' + expectedPublicKey,
+      type: 'EthereumAddress',
+      controller: 'did:ethr:' + expectedPublicKey,
+      name: 'Ethereum Account',
+      description: 'My Ethereum account.',
+      chain: Network.Ethereum,
+      addressIndex: 0,
+      accountIndex: 0,
+      address: expectedPublicKey,
+      encryptedPrivateKeyBytes
+    })
+  })
+
+  it('isEthereumCredential should validate credentials correctly', () => {
+    const args: EthereumDerivationArgs = {
+      network: Network.Ethereum,
+      addressIndex: 0,
+      accountIndex: 0
+    }
+
+    expect(isEthereumCredential(expectedGroupedCredentials, args)).toBeTruthy()
+  })
+
+  it('isEthereumCredential should return false for non-matching credentials', () => {
+    const args: EthereumDerivationArgs = {
+      network: Network.Ethereum,
+      addressIndex: 0,
+      accountIndex: 1 // Different account index
+    }
+    const notEthereumCredential: EthereumGroupedCredentials = {
+      '@context': ['https://w3id.org/wallet/v1'],
+      id: 'did:ethr:0xA98005e6ce8E62ADf8f9020fa99888E8f107e3C9',
+      type: 'EthereumAddress',
+      controller: 'did:ethr:0xA98005e6ce8E62ADf8f9020fa99888E8f107e3C9',
+      name: 'Ethereum Account',
+      description: 'My Ethereum account.',
+      chain: Network.Ethereum,
+      accountIndex: 0,
+      addressIndex: 0,
+      address: expectedPublicKey,
+      encryptedPrivateKeyBytes: new Uint8Array([0, 1, 2, 3, 4])
+    }
+
+    expect(isEthereumCredential(notEthereumCredential, args)).toBeFalsy()
+  })
+  it('check if it is an Ethereum derivation', () => {
+    const args: EthereumDerivationArgs = {
+      network: Network.Ethereum,
+      addressIndex: 0,
+      accountIndex: 1 // Different account index
+    }
+    expect(isEthereumDerivation(args)).toBeTruthy()
+  })
+  describe('Ethereum guards', () => {
+    describe('isTransaction', () => {
+      it('should return true for valid transaction objects', () => {
+        const validTransaction = {
+          to: '0x123456789abcdef',
+          value: '1000',
+          data: '0xabcdef'
+        }
+        expect(isTransaction(validTransaction)).toBeTruthy()
+      })
+
+      it('should return false for invalid transaction objects', () => {
+        const invalidTransaction = {
+          from: '0x123456789abcdef', // Missing required 'to', 'value', and 'data'
+          gasPrice: '5000'
+        }
+        expect(isTransaction(invalidTransaction)).toBeFalsy()
+      })
+
+      it('should return false for non-object types', () => {
+        expect(isTransaction('this is a string')).toBeFalsy()
+        expect(isTransaction(123)).toBeFalsy()
+        expect(isTransaction(null)).toBeFalsy()
+        expect(isTransaction(undefined)).toBeFalsy()
+      })
+    })
+
+    describe('isMessage', () => {
+      it('should return true for strings', () => {
+        expect(isMessage('Hello, blockchain!')).toBeTruthy()
+      })
+
+      it('should return true for Uint8Array', () => {
+        const messageBytes = new Uint8Array([1, 2, 3, 4, 5])
+        expect(isMessage(messageBytes)).toBeTruthy()
+      })
+
+      it('should return false for non-string and non-Uint8Array objects', () => {
+        expect(isMessage(123)).toBeFalsy()
+        expect(isMessage({ text: 'Hello, blockchain!' })).toBeFalsy()
+        expect(isMessage(null)).toBeFalsy()
+        expect(isMessage(undefined)).toBeFalsy()
+      })
+    })
+  })
+})

--- a/packages/key-management/test/ethereum/key-agent-base.test.ts
+++ b/packages/key-management/test/ethereum/key-agent-base.test.ts
@@ -168,7 +168,6 @@ describe('KeyAgentBase (Ethereum Functionality)', () => {
       expect(instance.knownCredentials[0]?.address.toLowerCase()).to.deep.equal(
         expectedGroupedCredentialsArray[0]?.address.toLowerCase()
       )
-      console.log('instance.knownCredentials', instance.knownCredentials)
       expect(instance.knownCredentials[1]?.address).to.deep.equal(
         expectedGroupedCredentialsArray[1]?.address
       )

--- a/packages/key-management/test/keyDecryptor.test.ts
+++ b/packages/key-management/test/keyDecryptor.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  generateMnemonicWords,
+  KeyAgentType,
+  KeyDecryptor,
+  mnemonicToSeed,
+  SerializableKeyAgentData
+} from '../src'
+import { emip3encrypt } from '../src/emip3'
+
+describe('KeyDecryptor', () => {
+  const passphrase = new Uint8Array([1, 2, 3, 4, 5])
+  const getPassphrase = async () => {
+    return await Promise.resolve(passphrase)
+  }
+  let mnemonic: string[]
+  let seed: Uint8Array
+  let encryptedPrivateKey: Uint8Array
+
+  beforeAll(async () => {
+    mnemonic = generateMnemonicWords()
+    seed = mnemonicToSeed(mnemonic, '')
+    encryptedPrivateKey = await emip3encrypt(
+      new Uint8Array([1, 2, 3]),
+      passphrase
+    )
+  })
+
+  it('decryptChildPrivateKey should decrypt properly', async () => {
+    const keyDecryptor = new KeyDecryptor(getPassphrase)
+    const encryptedPrivateKey = await emip3encrypt(seed, passphrase) // Reusing emip3 encrypt for the setup
+
+    const decryptedPrivateKey =
+      await keyDecryptor.decryptChildPrivateKey(encryptedPrivateKey)
+    expect(decryptedPrivateKey).toEqual(seed)
+  })
+
+  it('decryptSeedBytes should decrypt seed bytes properly', async () => {
+    const keyDecryptor = new KeyDecryptor(getPassphrase)
+    const encryptedSeedBytes = await emip3encrypt(seed, passphrase)
+    const serializableData: SerializableKeyAgentData = {
+      __typename: KeyAgentType.InMemory,
+      encryptedSeedBytes: encryptedSeedBytes,
+      id: 'http://example.gov/wallet/3732',
+      type: ['VerifiableCredential', 'EncryptedWallet'],
+      issuer: 'did:example:123',
+      issuanceDate: '2020-05-22T17:38:21.910Z',
+      credentialSubject: {
+        id: 'did:example:123',
+        contents: []
+      }
+    }
+
+    const decryptedBytes = await keyDecryptor.decryptSeedBytes(serializableData)
+    expect(decryptedBytes).toEqual(seed)
+  })
+
+  it('should throw an authentication error if decryption fails', async () => {
+    const keyDecryptor = new KeyDecryptor(getPassphrase)
+    const wrongEncryptedData = new Uint8Array([99, 99, 99]) // data that cannot be correctly decrypted
+
+    await expect(
+      keyDecryptor.decryptChildPrivateKey(wrongEncryptedData)
+    ).rejects.toThrow('Failed to decrypt child private key')
+  })
+
+  it('should throw an authentication error if decryption fails in decryptSeed', async () => {
+    const keyDecryptor = new KeyDecryptor(getPassphrase)
+    const wrongEncryptedData = new Uint8Array([99, 99, 99]) // data that cannot be correctly decrypted
+    const serializableData: SerializableKeyAgentData = {
+      __typename: KeyAgentType.InMemory,
+      encryptedSeedBytes: wrongEncryptedData, // intentionally incorrect data
+      id: 'http://example.gov/wallet/3732',
+      type: ['VerifiableCredential', 'EncryptedWallet'],
+      issuer: 'did:example:123',
+      issuanceDate: '2020-05-22T17:38:21.910Z',
+      credentialSubject: {
+        id: 'did:example:123',
+        contents: []
+      }
+    }
+
+    await expect(
+      keyDecryptor.decryptSeedBytes(serializableData)
+    ).rejects.toThrow('Failed to decrypt seed bytes')
+  })
+  it('should not expose passphrase', async () => {
+    const keyDecryptor = new KeyDecryptor(getPassphrase)
+    let exposedPassphrase = null
+
+    // Trying to intercept the passphrase by replacing the internal getPassphrase method
+    keyDecryptor.getPassphrase = () => {
+      exposedPassphrase = passphrase
+      return passphrase
+    }
+
+    await keyDecryptor.decryptChildPrivateKey(encryptedPrivateKey)
+
+    // Check if the passphrase was exposed
+    expect(exposedPassphrase).toBeNull()
+  })
+})

--- a/packages/key-management/test/mina/key-agent-base.test.ts
+++ b/packages/key-management/test/mina/key-agent-base.test.ts
@@ -6,7 +6,8 @@ import Client from 'mina-signer'
 import sinon from 'sinon'
 import { expect } from 'vitest'
 
-import { MinaSpecificArgs } from '../../src/chains/Mina'
+import { MinaDerivationArgs } from '../../dist'
+import { deriveMinaPrivateKey, MinaSpecificArgs } from '../../src/chains/Mina'
 import { reverseBytes } from '../../src/chains/Mina/keyDerivationUtils'
 import { emip3encrypt } from '../../src/emip3'
 import { getPassphraseRethrowTypedError } from '../../src/InMemoryKeyAgent'
@@ -21,10 +22,16 @@ import * as util from '../../src/util/bip39'
 
 // Provide the passphrase for testing purposes
 const params = {
-  passphrase: 'passphrase'
+  passphrase: 'passphrase',
+  incorrectPassphrase: 'not correct passphrase'
 }
 const getPassphrase = () =>
   new Promise<Uint8Array>((resolve) => resolve(Buffer.from(params.passphrase)))
+
+const getWrongPassphrase = () =>
+  new Promise<Uint8Array>((resolve) =>
+    resolve(Buffer.from(params.incorrectPassphrase))
+  )
 
 describe('KeyAgentBase (Mina Functionality)', () => {
   class KeyAgentBaseInstance extends KeyAgentBase {
@@ -40,6 +47,7 @@ describe('KeyAgentBase (Mina Functionality)', () => {
   let rootKeyBytes: Uint8Array
   let encryptedSeedBytes: Uint8Array
   let mnemonic: string[]
+  let seed: Uint8Array
 
   beforeEach(async () => {
     // Generate a mnemonic (24 words)
@@ -58,7 +66,7 @@ describe('KeyAgentBase (Mina Functionality)', () => {
       'alert',
       'like'
     ]
-    const seed = util.mnemonicToSeed(mnemonic)
+    seed = util.mnemonicToSeed(mnemonic)
     // Create root node from seed
     const root = bip32.HDKey.fromMasterSeed(seed)
     // unencrypted root key bytes
@@ -103,6 +111,29 @@ describe('KeyAgentBase (Mina Functionality)', () => {
 
     it('should return the correct empty serializableData', () => {
       expect(instance.serializableData).to.deep.equal(serializableData)
+    })
+
+    it('should derive a mina private key', () => {
+      const args: MinaDerivationArgs = {
+        network: Network.Mina,
+        accountIndex: 0,
+        addressIndex: 0
+      }
+      const childPrivateKey = deriveMinaPrivateKey(args, seed)
+      expect(childPrivateKey).toBe(
+        'EKExKH31gXH7t5KiYxdyEbtgi22vgX6wnqwmcbrANs9nQJt487iN'
+      )
+    })
+    it('should throw an error for wrong seed length', () => {
+      const args: MinaDerivationArgs = {
+        network: Network.Mina,
+        accountIndex: 0,
+        addressIndex: 0
+      }
+      const emptySeed = new Uint8Array([]) // Seed length of zero
+      expect(() => deriveMinaPrivateKey(args, emptySeed)).toThrow(
+        'HDKey: wrong seed length=0. Should be between 128 and 512 bits; 256 bits is advised'
+      )
     })
 
     it('should derive correct Mina address', async () => {
@@ -176,6 +207,24 @@ describe('KeyAgentBase (Mina Functionality)', () => {
       expect(groupedCredential.address).to.deep.equal(
         expectedGroupedCredentials.address
       )
+    })
+
+    it('should derive fail to correct address for account index other than 0 on wrong network', async () => {
+      const args: MinaDerivationArgs = {
+        network: 'NotASupportedNetwork' as Network,
+        accountIndex: 1,
+        addressIndex: 0
+      }
+
+      try {
+        await instance.deriveCredentials(args, getPassphrase, true)
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        // Check the error message to contain specific text indicating the type of error
+        expect(error.message).toContain(
+          'Unsupported network: NotASupportedNetwork'
+        )
+      }
     })
 
     it('should derive multiple unique Mina addresses for each account index and store credentials properly', async () => {
@@ -348,6 +397,57 @@ describe('KeyAgentBase (Mina Functionality)', () => {
       )
       expect(isVerified).toBeTruthy()
     })
+    it('should fail to sign a message because of an unsupported network', async () => {
+      const expectedPublicKey: Mina.PublicKey =
+        'B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb'
+
+      const expectedGroupedCredentials = {
+        '@context': ['https://w3id.org/wallet/v1'],
+        id: 'did:mina:B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb',
+        type: 'MinaAddress',
+        controller:
+          'did:mina:B62qjsV6WQwTeEWrNrRRBP6VaaLvQhwWTnFi4WP4LQjGvpfZEumXzxb',
+        name: 'Mina Account',
+        description: 'My Mina account.',
+        chain: Network.Mina,
+        accountIndex: 0,
+        addressIndex: 0,
+        address: expectedPublicKey
+      }
+
+      const args: MinaSpecificArgs = {
+        network: Network.Mina,
+        accountIndex: 0,
+        addressIndex: 0,
+        networkType: networkType
+      }
+
+      const groupedCredential = await instance.deriveCredentials(
+        args,
+        getPassphrase,
+        true
+      )
+      expect(groupedCredential.address).to.deep.equal(
+        expectedGroupedCredentials.address
+      )
+
+      const message: Mina.MessageBody = {
+        message: 'Hello, Bob!'
+      }
+
+      try {
+        await instance.sign(groupedCredential, message, {
+          network: 'NotAMinaNetwork' as Network,
+          operation: 'mina_sign',
+          networkType: 'testnet'
+        } as ChainOperationArgs)
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        // Check the error message to contain specific text indicating the type of error
+        expect(error.message).toContain('Unsupported network')
+      }
+    })
+
     it('should use the generic sign<T> function to sign fields correctly and the client should be able to verify it', async () => {
       // Define a mocked publicKey, which should be expected from the derivation
       const expectedPublicKey: Mina.PublicKey =
@@ -432,7 +532,6 @@ describe('KeyAgentBase (Mina Functionality)', () => {
         } as ChainOperationArgs
       )
 
-      console.log('createdNullifier', createdNullifier)
       expect(createdNullifier).not.toBeUndefined()
     })
     it('should use the generic sign<T> function to create a nullifier using the args `operation` field --correctly and the client should be able to verify it', async () => {
@@ -467,6 +566,57 @@ describe('KeyAgentBase (Mina Functionality)', () => {
       )
 
       expect(createdNullifier).not.toBeUndefined()
+    })
+
+    it('should decrypt seed successfully', async () => {
+      const decryptedSeed = await instance.decryptSeed()
+      expect(decryptedSeed).to.deep.equal(seed)
+    })
+
+    it('should fail to decrypt seed successfully', async () => {
+      const newFaultyInstance = new KeyAgentBaseInstance(
+        serializableData,
+        getWrongPassphrase
+      )
+
+      try {
+        await newFaultyInstance.decryptSeed()
+        // If no error is thrown, force the test to fail
+        throw new Error(
+          'Expected decryptSeed to throw an AuthenticationError, but it did not throw'
+        )
+      } catch (error) {
+        // Check that the error is an instance of Error
+        expect(error).toBeInstanceOf(Error)
+        // Check the error message to contain specific text indicating the type of error
+        expect(error.message).toContain('Failed to decrypt root private key')
+        expect(error.message).toContain('AuthenticationError')
+        expect(error.message).toContain('Failed to decrypt seed bytes')
+        expect(error.message).toContain('invalid tag')
+      }
+    })
+
+    it('should fail to export root key successfully', async () => {
+      const newFaultyInstance = new KeyAgentBaseInstance(
+        serializableData,
+        getWrongPassphrase
+      )
+
+      try {
+        await newFaultyInstance.exportRootPrivateKey()
+        // If no error is thrown, force the test to fail
+        throw new Error(
+          'Expected decryptSeed to throw an AuthenticationError, but it did not throw'
+        )
+      } catch (error) {
+        // Check that the error is an instance of Error
+        expect(error).toBeInstanceOf(Error)
+        // Check the error message to contain specific text indicating the type of error
+        expect(error.message).toContain('Failed to export root private key')
+        expect(error.message).toContain('AuthenticationError')
+        expect(error.message).toContain('Failed to decrypt seed bytes')
+        expect(error.message).toContain('invalid tag')
+      }
     })
   })
 })

--- a/packages/key-management/test/util/guards.test.ts
+++ b/packages/key-management/test/util/guards.test.ts
@@ -89,9 +89,6 @@ describe('Guard functions tests', () => {
       // missing 'command'
     }
 
-    const a = isZkAppTransaction(zkAppCommand)
-    console.log('a which is expected to be true is:', a)
-
     expect(isZkAppTransaction(zkAppCommand)).toBe(true)
     expect(isZkAppTransaction(invalidPayload)).toBe(false)
   })

--- a/packages/vault/src/vault/utils/sign.ts
+++ b/packages/vault/src/vault/utils/sign.ts
@@ -2,7 +2,8 @@ import {
   ChainOperationArgs,
   ChainSignablePayload,
   GetPassphrase,
-  GroupedCredentials
+  GroupedCredentials,
+  InMemoryKeyAgent
 } from '@palladxyz/key-management'
 
 import { WalletError } from '../../lib/Errors'
@@ -30,7 +31,9 @@ export async function signHelper(
   }
   const credential = currentWallet.credential.credential as GroupedCredentials
 
-  const keyAgent = restoreKeyAgent(keyAgentState.name, getPassphrase)
+  let keyAgent: InMemoryKeyAgent | undefined | null
+  keyAgent = restoreKeyAgent(keyAgentState.name, getPassphrase)
   const signed = await keyAgent?.sign(credential, signable, args)
+  keyAgent = null
   return signed
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.2
         version: 17.0.3
+      '@vitest/coverage-v8':
+        specifier: ^1.5.0
+        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(happy-dom@12.10.3))
 
   packages/mina-core:
     dependencies:
@@ -3449,6 +3452,11 @@ packages:
     peerDependencies:
       vitest: '>=0.30.0 <1'
 
+  '@vitest/coverage-v8@1.5.0':
+    resolution: {integrity: sha512-1igVwlcqw1QUMdfcMlzzY4coikSIBN944pkueGi0pawrX5I5Z+9hxdTR+w3Sg6Q3eZhvdMAs8ZaF9JuTG1uYOQ==}
+    peerDependencies:
+      vitest: 1.5.0
+
   '@vitest/expect@0.34.6':
     resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
 
@@ -5715,6 +5723,10 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
+  istanbul-lib-source-maps@5.0.4:
+    resolution: {integrity: sha512-wHOoEsNJTVltaJp8eVkm8w+GVkVNHT2YDYo53YdzQEL2gWm1hBX5cGFR9hQJtuGLebidVX7et3+dmDZrmclduw==}
+    engines: {node: '>=10'}
+
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
@@ -6009,6 +6021,9 @@ packages:
   magic-string@0.30.9:
     resolution: {integrity: sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==}
     engines: {node: '>=12'}
+
+  magicast@0.3.4:
+    resolution: {integrity: sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -11580,6 +11595,25 @@ snapshots:
       std-env: 3.7.0
       vitest: 1.5.0(@types/node@20.12.7)(happy-dom@12.10.3)
 
+  '@vitest/coverage-v8@1.5.0(vitest@1.5.0(@types/node@20.12.7)(happy-dom@12.10.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.4
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.9
+      magicast: 0.3.4
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      test-exclude: 6.0.0
+      vitest: 1.5.0(@types/node@20.12.7)(happy-dom@12.10.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@0.34.6':
     dependencies:
       '@vitest/spy': 0.34.6
@@ -14285,6 +14319,14 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
+  istanbul-lib-source-maps@5.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-reports@3.1.7:
     dependencies:
       html-escaper: 2.0.2
@@ -14595,6 +14637,12 @@ snapshots:
   magic-string@0.30.9:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  magicast@0.3.4:
+    dependencies:
+      '@babel/parser': 7.24.4
+      '@babel/types': 7.24.0
+      source-map-js: 1.2.0
 
   make-dir@4.0.0:
     dependencies:


### PR DESCRIPTION
## Describe changes
The `key-management` had low test coverage originally ~50%, added some new tests and now up to ~80%
<img width="765" alt="Screenshot 2024-04-22 at 22 29 06" src="https://github.com/palladians/pallad/assets/164676295/844e1c6f-352e-44fc-b581-8cf560095235">
