### PR TITLE
Add a  password strength label

### DIFF
--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -43,6 +43,7 @@
     "@palladxyz/pallad-core": "workspace:*",
     "@palladxyz/vault": "workspace:*",
     "@total-typescript/ts-reset": "0.5.1",
+    "@zxcvbn-ts/core": "^3.0.4",
     "array-shuffle": "3.0.0",
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.1",

--- a/packages/features/src/onboarding/components/wallet-info-form.tsx
+++ b/packages/features/src/onboarding/components/wallet-info-form.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
+import { zxcvbn } from "@zxcvbn-ts/core"
 import { ExternalLinkIcon, EyeIcon, EyeOffIcon } from "lucide-react"
 import { useState } from "react"
 import { useForm } from "react-hook-form"
@@ -20,6 +21,22 @@ const formSchema = z.object({
   spendingPassword: passwordSchema,
 })
 
+const getPasswordStrengthConfig = (score: number) => {
+  switch (score) {
+    case 0:
+    case 1:
+      return ["Not the best", "#EB6F92"]
+    case 2:
+      return ["Weak", "#F2BEBC"]
+    case 3:
+      return ["OK and could be better", "#F2BEBC"]
+    case 4:
+      return ["Safe", "#A3DBE4"]
+    default:
+      return ["", ""]
+  }
+}
+
 export const WalletInfoForm = ({ title, onSubmit }: WalletInfoFormProps) => {
   const [showPassword, setShowPassword] = useState(false)
   const [termsAccepted, setTermsAccepted] = useState(false)
@@ -28,6 +45,7 @@ export const WalletInfoForm = ({ title, onSubmit }: WalletInfoFormProps) => {
     register,
     handleSubmit,
     formState: { errors, dirtyFields },
+    watch,
   } = useForm({
     defaultValues: {
       walletName: "",
@@ -35,6 +53,10 @@ export const WalletInfoForm = ({ title, onSubmit }: WalletInfoFormProps) => {
     },
     resolver: zodResolver(formSchema),
   })
+  const [strengthLabel, strengthColor] = getPasswordStrengthConfig(
+    zxcvbn(watch("spendingPassword")).score,
+  )
+
   return (
     <WizardLayout
       title={title}
@@ -114,6 +136,16 @@ export const WalletInfoForm = ({ title, onSubmit }: WalletInfoFormProps) => {
             >
               {showPassword ? <EyeOffIcon size={24} /> : <EyeIcon size={24} />}
             </button>
+          </label>
+          <label className="text-[#7D7A9C] text-sm my-2 h-px">
+            {dirtyFields.spendingPassword && (
+              <span>
+                Your password is...
+                <span style={{ color: strengthColor }} className="px-2">
+                  {strengthLabel}
+                </span>
+              </span>
+            )}
           </label>
           {errors.spendingPassword && (
             <FormError>{errors.spendingPassword?.message}</FormError>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       '@total-typescript/ts-reset':
         specifier: 0.5.1
         version: 0.5.1
+      '@zxcvbn-ts/core':
+        specifier: ^3.0.4
+        version: 3.0.4
       array-shuffle:
         specifier: 3.0.0
         version: 3.0.0
@@ -334,7 +337,7 @@ importers:
         version: 2.4.0
       tailwindcss-animate:
         specifier: 1.0.7
-        version: 1.0.7(tailwindcss@3.4.7(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.12))(@types/node@22.0.0)(typescript@5.5.4)))
+        version: 1.0.7
       webext-bridge:
         specifier: 6.0.1
         version: 6.0.1
@@ -2892,6 +2895,9 @@ packages:
   '@xstate/fsm@1.6.5':
     resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
 
+  '@zxcvbn-ts/core@3.0.4':
+    resolution: {integrity: sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw==}
+
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -4308,6 +4314,10 @@ packages:
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastparse@1.1.2:
     resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
@@ -10013,6 +10023,10 @@ snapshots:
 
   '@xstate/fsm@1.6.5': {}
 
+  '@zxcvbn-ts/core@3.0.4':
+    dependencies:
+      fastest-levenshtein: 1.0.16
+
   abbrev@2.0.0: {}
 
   abitype@1.0.5(typescript@5.5.4)(zod@3.23.8):
@@ -11562,6 +11576,8 @@ snapshots:
       boolean: 3.2.0
 
   fast-redact@3.5.0: {}
+
+  fastest-levenshtein@1.0.16: {}
 
   fastparse@1.1.2: {}
 
@@ -14693,6 +14709,8 @@ snapshots:
   tabbable@6.2.0: {}
 
   tailwind-merge@2.4.0: {}
+
+  tailwindcss-animate@1.0.7: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.7(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.12))(@types/node@22.0.0)(typescript@5.5.4))):
     dependencies:


### PR DESCRIPTION
## Describe changes

fix #193 

Changes:
- Added new dep `zxcvbn-ts/core`
- Implemented a password strength label based on user input. 
- Since `zxcvbn` returns 5 levels which is more granular, I added a intermediate level of text





## Ticket or discussion link

## Review checklist

- [ ] Proper documentation added
- [ ] Proper tests added

## Screenshots

https://github.com/user-attachments/assets/b99f4a64-2004-403f-825e-b0b1c583cb76

