### PR TITLE
Fix `The spending password is wrong` label in Unlock Wallet route

### DIFF
--- a/packages/features/src/lock/routes/unlock-wallet.tsx
+++ b/packages/features/src/lock/routes/unlock-wallet.tsx
@@ -17,6 +17,7 @@ const formSchema = z.object({
 export const UnlockWalletRoute = () => {
   const [restartAlertVisible, setRestartAlertVisible] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
+  const [formSubmitted, setFormSubmitted] = useState(false)
   const navigate = useNavigate()
   const unlockWalletForm = useForm({
     defaultValues: {
@@ -29,6 +30,7 @@ export const UnlockWalletRoute = () => {
   }: {
     spendingPassword: string
   }) => {
+    setFormSubmitted(true)
     await sessionPersistence.setItem("spendingPassword", spendingPassword)
     await useVault.persist.rehydrate()
     setTimeout(() => {
@@ -45,6 +47,7 @@ export const UnlockWalletRoute = () => {
   // biome-ignore lint: won't update
   useEffect(() => {
     const unsub = useVault.persist?.onFinishHydration(async () => {
+      if (!formSubmitted) return
       const authenticated = (await securePersistence.getItem("foo")) === "bar"
       if (!authenticated) {
         await sessionPersistence.removeItem("spendingPassword")
@@ -56,7 +59,7 @@ export const UnlockWalletRoute = () => {
       navigate("/dashboard")
     })
     return () => unsub?.()
-  }, [])
+  }, [formSubmitted])
   return (
     <UnlockWalletView
       form={unlockWalletForm}


### PR DESCRIPTION
### Problem:
- `The spending password is wrong` is displayed on Unlock Wallet route even if user didn't provide a wrong password.

closes: #197

## Issue ticket number and link:
- **Ticket Number:** [ 197 ]
- **Link:** [ https://github.com/palladians/pallad/issues/197 ]

### Evidence:

https://www.loom.com/share/0499b3a84ed444cda04d904300c4a1f6

![image](https://github.com/user-attachments/assets/89c34dad-5b69-4874-82b9-47467e6a5a22)

![image](https://github.com/user-attachments/assets/29b18310-3a60-4202-ba14-6d6a56d99a95)

### Acceptance Criteria
- [x]  The label is only visible after user provided a wrong password.
