### PR TITLE
Add Word Number Labels to Mnemonic Inputs in Wallet Restoration Flow

### DIFF
--- a/packages/features/src/components/autocomplete.tsx
+++ b/packages/features/src/components/autocomplete.tsx
@@ -20,6 +20,7 @@ type AutocompleteProps = {
   autoFocus?: boolean
   testId: string
   inputProps: UseFormRegisterReturn
+  wordNumber: number
 }
 
 export const Autocomplete = ({
@@ -31,20 +32,25 @@ export const Autocomplete = ({
   testId,
   inputProps,
   setValue,
+  wordNumber,
 }: AutocompleteProps) => {
   const filteredOptions = take(3, matchSorter(options, currentValue))
   return (
-    <div className="dropdown">
+    <div className="dropdown relative">
       <Combobox value={currentValue} onChange={setValue}>
         <ComboboxInput
-          className="input text-sm w-full bg-[#413E5E]"
+          className="input text-sm w-full bg-[#413E5E] pl-6 caret-[#eec382]"
           placeholder={placeholder}
           autoFocus={autoFocus}
           onPaste={onPaste}
           autoComplete="off"
           data-testid={testId}
           {...inputProps}
+          style={{ position: "relative" }}
         />
+        <span className="absolute left-2 top-1/2 transform -translate-y-1/2 text-[#afd9e2] pointer-events-none">
+          {wordNumber}.
+        </span>
         <ComboboxOptions
           className={clsx(
             "dropdown-content z-10 menu shadow p-2 bg-secondary rounded-box w-28 empty:invisible",

--- a/packages/features/src/components/autocomplete.tsx
+++ b/packages/features/src/components/autocomplete.tsx
@@ -41,7 +41,7 @@ export const Autocomplete = ({
         <ComboboxInput
           className={clsx(
             "input text-sm w-full bg-[#413E5E] caret-[#eec382]",
-            wordNumber > 9 ? "pl-8" : "pl-6"
+            wordNumber > 9 ? "pl-8" : "pl-6",
           )}
           placeholder={placeholder}
           autoFocus={autoFocus}

--- a/packages/features/src/components/autocomplete.tsx
+++ b/packages/features/src/components/autocomplete.tsx
@@ -39,7 +39,10 @@ export const Autocomplete = ({
     <div className="dropdown relative">
       <Combobox value={currentValue} onChange={setValue}>
         <ComboboxInput
-          className="input text-sm w-full bg-[#413E5E] pl-6 caret-[#eec382]"
+          className={clsx(
+            "input text-sm w-full bg-[#413E5E] caret-[#eec382]",
+            wordNumber > 9 ? "pl-8" : "pl-5"
+          )}
           placeholder={placeholder}
           autoFocus={autoFocus}
           onPaste={onPaste}

--- a/packages/features/src/components/autocomplete.tsx
+++ b/packages/features/src/components/autocomplete.tsx
@@ -41,7 +41,7 @@ export const Autocomplete = ({
         <ComboboxInput
           className={clsx(
             "input text-sm w-full bg-[#413E5E] caret-[#eec382]",
-            wordNumber > 9 ? "pl-8" : "pl-5"
+            wordNumber > 9 ? "pl-8" : "pl-6"
           )}
           placeholder={placeholder}
           autoFocus={autoFocus}

--- a/packages/features/src/onboarding/views/seed-import.tsx
+++ b/packages/features/src/onboarding/views/seed-import.tsx
@@ -51,7 +51,7 @@ export const SeedImportView = ({
           <Autocomplete
             // biome-ignore lint: hardcoded
             key={i}
-            placeholder={`${wordLabel}.`}
+            placeholder=""
             options={wordlist}
             autoFocus={i === 0}
             currentValue={form.watch(`mnemonic.${i}`)}
@@ -70,6 +70,7 @@ export const SeedImportView = ({
               form.setValue(`mnemonic.${i}`, newValue)
             }
             inputProps={form.register(`mnemonic.${i}`, { value: "" })}
+            wordNumber={wordLabel}
           />
         ))}
       </div>


### PR DESCRIPTION
### Problem:
- The word number label disappears when the user types in the mnemonic input field.

closes: #190

## Issue ticket number and link:
- **Ticket Number:** [ 190 ]
- **Link:** [ https://github.com/palladians/pallad/issues/190 ]

### Evidence:

https://www.loom.com/share/7cc9a86b55ce4457ba6b943530f5b633

![image](https://github.com/user-attachments/assets/4c9fff35-3806-43e1-b9f9-11a420278777)

### Acceptance Criteria
- [x]   Each Seed Import input should have a label inside the input with an according word number.
- [x] It should work fine on smaller side panels - inputs should be responsive.
