### PR TITLE
Fix Date Formatting on Hover in Mina Price Chart

### DIFF
--- a/packages/features/src/wallet/routes/overview.tsx
+++ b/packages/features/src/wallet/routes/overview.tsx
@@ -45,7 +45,7 @@ export const OverviewRoute = () => {
       ? `${dailyPriceDiff >= 0 ? "+" : "-"}${
           useFiatBalance ? dailyPriceDiffFiat : dailyPriceDiffMina
         } (24h)`
-      : dayjs(lastMonthPrices[currentPriceIndex]?.[0]).format("MMM d")
+      : dayjs(lastMonthPrices[currentPriceIndex]?.[0]).format("MMM D")
   return (
     <OverviewView
       lastMonthPrices={lastMonthPrices}


### PR DESCRIPTION
### Problem:
- Date is formatted with a 3 letters month abbreviation and one digit of a month's day. (Jul 0)

closes: #191

## Issue ticket number and link:
- **Ticket Number:** [ 191 ]
- **Link:** [ https://github.com/palladians/pallad/issues/191 ]

### Evidence:

https://www.loom.com/share/1335edf5af5846218c5e9469830b3313

### Acceptance Criteria
- [x]   Date formatted with a 3 letters month abbreviation and one or two digits of month's day. (Jul 30)
