### PR TITLE
Allow authorizing non-HTTPS apps with a dev build of Pallad

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ VITE_APP_E2E=false
 VITE_APP_DEFAULT_NETWORK=Devnet
 VITE_APP_MINA_PROXY_MAINNET_URL=https://api.minascan.io/node/mainnet/v1/graphql
 VITE_APP_MINA_PROXY_DEVNET_URL=https://api.minascan.io/node/devnet/v1/graphql
+VITE_APP_DEV_MODE=false

--- a/apps/extension/manifest.ts
+++ b/apps/extension/manifest.ts
@@ -1,6 +1,7 @@
 import packageJson from "./package.json" with { type: "json" }
 
 const isDevMode = process.env.VITE_APP_DEV_MODE === "true"
+const rpcMatches = ["https://*/*", ...(isDevMode ? ["http://*/*"] : [])]
 
 export const manifest: chrome.runtime.ManifestV3 = {
   manifest_version: 3,
@@ -23,7 +24,7 @@ export const manifest: chrome.runtime.ManifestV3 = {
   },
   content_scripts: [
     {
-      matches: ["https://*/*", ...(isDevMode ? ["http://*/*"] : [])],
+      matches: rpcMatches,
       js: ["src/inject/index.ts"],
       run_at: "document_start",
       all_frames: true,
@@ -32,7 +33,7 @@ export const manifest: chrome.runtime.ManifestV3 = {
   web_accessible_resources: [
     {
       resources: ["rpc.js"],
-      matches: ["https://*/*"],
+      matches: rpcMatches,
     },
   ],
   host_permissions: ["https://*/*"],

--- a/apps/extension/manifest.ts
+++ b/apps/extension/manifest.ts
@@ -1,6 +1,6 @@
 import packageJson from "./package.json" with { type: "json" }
 
-const isDevMode = process.env.VITE_APP_DEV_MODE === 'true';
+const isDevMode = process.env.VITE_APP_DEV_MODE === "true"
 
 export const manifest: chrome.runtime.ManifestV3 = {
   manifest_version: 3,

--- a/apps/extension/manifest.ts
+++ b/apps/extension/manifest.ts
@@ -1,5 +1,7 @@
 import packageJson from "./package.json" with { type: "json" }
 
+const isDevMode = process.env.VITE_APP_DEV_MODE === 'true';
+
 export const manifest: chrome.runtime.ManifestV3 = {
   manifest_version: 3,
   name: "Pallad",
@@ -21,7 +23,7 @@ export const manifest: chrome.runtime.ManifestV3 = {
   },
   content_scripts: [
     {
-      matches: ["https://*/*"],
+      matches: ["https://*/*", ...(isDevMode ? ["http://*/*"] : [])],
       js: ["src/inject/index.ts"],
       run_at: "document_start",
       all_frames: true,

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@palladxyz/extension",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "b": "pnpm build",
-    "build:extension": "VITE_APP_DEV_MODE=true turbo run build --filter=@palladxyz/extension...",
+    "build:extension": "turbo run build --filter=@palladxyz/extension...",
     "build:features": "turbo run build --filter=@palladxyz/features...",
     "story:features": "turbo run story:build --filter=@palladxyz/features",
     "dev:extension": "turbowatch extension.turbowatch.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "b": "pnpm build",
-    "build:extension": "turbo run build --filter=@palladxyz/extension...",
+    "build:extension": "VITE_APP_DEV_MODE=true turbo run build --filter=@palladxyz/extension...",
     "build:features": "turbo run build --filter=@palladxyz/features...",
     "story:features": "turbo run story:build --filter=@palladxyz/features",
     "dev:extension": "turbowatch extension.turbowatch.ts",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@palladxyz/features",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "",
   "type": "module",
   "module": "dist/index.js",


### PR DESCRIPTION
### Problem:
- Pallad's extension currently restricts content scripts to HTTPS sites, preventing testing on local non-HTTPS environments. This limitation hinders developers from easily testing and authorizing the extension in non-HTTPS apps during development.

closes: #195

## Issue ticket number and link:
- **Ticket Number:** [ 195 ]
- **Link:** [ https://github.com/palladians/pallad/issues/195 ]

### Acceptance Criteria
- [x]  Feature Flag: Add `VITE_APP_DEV_MODE` to `.env.example.`
- [x] Manifest Update: If `VITE_APP_DEV_MODE === 'true'`, include `http://*/*` in the content script matches array in `manifest.ts`.
- [x] Build Behavior: When built with `VITE_APP_DEV_MODE=true`, allow content scripts in non-HTTPS apps.
