### PR TITLE
chore(web connector): handle gql errors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,15 +5,12 @@
   },
   "files": {
     "ignore": [
-      "apps/**/playwright-report/**/*",
-      "apps/**/dist/*.js",
-      "apps/**/public/rpc.js",
-      "apps/**/dist/*.ts",
-      "apps/**/dist/*.json",
-      "packages/**/build/**/*",
-      "packages/**/dist/*.js",
-      "packages/**/dist/*.ts",
-      "packages/**/dist/*.json"
+      "**/playwright-report/**/*",
+      "**/dist/**/*",
+      "**/public/**/*",
+      "**/build/**/*",
+      "**/.turbo/**/*",
+      "**/node_modules/**/*"
     ]
   },
   "linter": {

--- a/packages/providers/src/mina-node/utils/fetch-utils.ts
+++ b/packages/providers/src/mina-node/utils/fetch-utils.ts
@@ -3,12 +3,12 @@ import { GraphQLClient } from "graphql-request"
 import { customFetch } from "./custom-fetch"
 import { defaultJsonSerializer } from "./json-serializer"
 
-type ErrorPolicy = "ignore" | "all" // Define more types if needed
+type ErrorPolicy = "ignore" | "all" | "none" // Define more types if needed
 type FetchFunctionType = typeof fetch // Assuming you are using the standard Fetch API
 
 export const createGraphQLRequest = (
   url: string,
-  errorPolicy: ErrorPolicy = "ignore",
+  errorPolicy: ErrorPolicy = "none",
   fetchFunction: FetchFunctionType | undefined = undefined,
 ) => {
   const graphqlClient = new GraphQLClient(url, {

--- a/packages/web-provider/src/mina-network/mina-provider.ts
+++ b/packages/web-provider/src/mina-network/mina-provider.ts
@@ -359,7 +359,16 @@ export class MinaProvider extends EventEmitter {
         })
         if (passphrase === null)
           throw this.createProviderRpcError(4100, "Unauthorized.")
-        return this._vault.submitTransaction(requestData) as unknown as T
+        try {
+          return (await this._vault.submitTransaction(
+            requestData,
+          )) as unknown as T
+        } catch (error: any) {
+          throw this.createProviderRpcError(
+            4100,
+            "Unauthorized. Coudldn't broadscast transaction. Make sure nonce is correct.",
+          )
+        }
       }
 
       default:


### PR DESCRIPTION
## Describe changes
- Mina Node GraphQL client will now throw on any error.

## Ticket or discussion link

## Review checklist

- [ ] Proper documentation added
- [ ] Proper tests added

## Screenshots
