### PR TITLE
feat: add proper labels for unlock wallet prompt buttons

### DIFF
--- a/packages/features/src/web-connector/components/input-form.tsx
+++ b/packages/features/src/web-connector/components/input-form.tsx
@@ -4,12 +4,16 @@ import { type SubmitHandler, useForm } from "react-hook-form"
 import type { UserInputForm } from "../types"
 
 export const InputForm = ({
+  submitButtonLabel,
   onSubmit,
+  rejectButtonLabel,
   onReject,
   inputType,
   loading,
 }: {
+  submitButtonLabel?: string
   onSubmit: SubmitHandler<UserInputForm>
+  rejectButtonLabel?: string
   onReject: () => void
   inputType: string
   loading: boolean
@@ -52,7 +56,7 @@ export const InputForm = ({
         className="btn btn-primary max-w-48 w-full"
         disabled={loading}
       >
-        Sign
+        {submitButtonLabel ?? "Sign"}
       </button>
       <button
         type="button"
@@ -60,7 +64,7 @@ export const InputForm = ({
         onClick={onReject}
         disabled={loading}
       >
-        Reject
+        {rejectButtonLabel ?? "Reject"}
       </button>
     </form>
   )

--- a/packages/features/src/web-connector/routes/web-connector.tsx
+++ b/packages/features/src/web-connector/routes/web-connector.tsx
@@ -16,6 +16,8 @@ const sanitizePayload = async (payload: string) => {
 
 type ActionRequest = {
   title: string
+  submitButtonLabel?: string
+  rejectButtonLabel?: string
   payload: string
   inputType: "text" | "password" | "confirmation"
   loading: boolean
@@ -70,6 +72,8 @@ export const WebConnectorRoute = () => {
       if (message.type === "action_request") {
         setRequest({
           title: message.params.title,
+          submitButtonLabel: message.params.submitButtonLabel,
+          rejectButtonLabel: message.params.rejectButtonLabel,
           payload: await sanitizePayload(message.params.payload),
           inputType: message.params.inputType,
           loading: false,
@@ -84,7 +88,9 @@ export const WebConnectorRoute = () => {
         inputType={request.inputType}
         onConfirm={confirm}
         onDecline={decline}
+        rejectButtonLabel={request.rejectButtonLabel}
         onReject={reject}
+        submitButtonLabel={request.submitButtonLabel}
         onSubmit={onSubmit}
         title={request.title}
         payload={request.payload}

--- a/packages/features/src/web-connector/views/web-connector.tsx
+++ b/packages/features/src/web-connector/views/web-connector.tsx
@@ -12,7 +12,9 @@ type WebConnectorViewProps = {
   inputType: string
   onConfirm: () => void
   onDecline: () => void
+  rejectButtonLabel?: string
   onReject: () => void
+  submitButtonLabel?: string
   onSubmit: SubmitHandler<UserInputForm>
   loading: boolean
 }
@@ -22,8 +24,10 @@ export const WebConnectorView = ({
   payload,
   inputType,
   onDecline,
+  rejectButtonLabel,
   onReject,
   onConfirm,
+  submitButtonLabel,
   onSubmit,
   loading,
 }: WebConnectorViewProps) => {
@@ -58,7 +62,9 @@ export const WebConnectorView = ({
               {["text", "password"].includes(inputType) && (
                 <InputForm
                   inputType={inputType}
+                  submitButtonLabel={submitButtonLabel}
                   onSubmit={onSubmit}
+                  rejectButtonLabel={rejectButtonLabel}
                   onReject={onReject}
                   loading={loading}
                 />

--- a/packages/web-provider/src/mina-network/mina-provider.ts
+++ b/packages/web-provider/src/mina-network/mina-provider.ts
@@ -67,6 +67,8 @@ export class MinaProvider extends EventEmitter {
       inputType: "password",
       metadata: {
         title: "Unlock your wallet",
+        submitButtonLabel: "Unlock",
+        rejectButtonLabel: "Cancel",
       },
     })
     if (passphrase === null)

--- a/packages/web-provider/src/utils/prompts.ts
+++ b/packages/web-provider/src/utils/prompts.ts
@@ -1,5 +1,10 @@
 type InputType = "text" | "password" | "confirmation"
-type Metadata = { title: string; payload?: string }
+type Metadata = {
+  title: string
+  submitButtonLabel?: string
+  rejectButtonLabel?: string
+  payload?: string
+}
 
 export const showUserPrompt = async ({
   inputType,
@@ -44,6 +49,8 @@ export const showUserPrompt = async ({
                 type: "action_request",
                 params: {
                   title: metadata.title,
+                  submitButtonLabel: metadata.submitButtonLabel,
+                  rejectButtonLabel: metadata.rejectButtonLabel,
                   payload: metadata.payload ?? "{}",
                   inputType,
                   emitConnected,


### PR DESCRIPTION
The current button label ('Sign') for unlocking a user's wallet may be unclear. This PR updates the button labels to 'Unlock' and 'Cancel' for better clarity.
![Screenshot from 2024-10-20 17-20-07](https://github.com/user-attachments/assets/01962a1b-0f87-4f10-8216-e32672f8462d)
