### PR TITLE
feat: add mina_requestAccounts provider method and return an empty ar…

### DIFF
--- a/apps/extension/src/background/handlers/web-provider.ts
+++ b/apps/extension/src/background/handlers/web-provider.ts
@@ -83,7 +83,7 @@ export const minaRequestAccounts: Handler = async ({ data }) => {
     const provider = await MinaProvider.getInstance()
     const params = Validation.requestSchema.parse(data)
     return await provider.request({
-      method: "mina_accounts",
+      method: "mina_requestAccounts",
       params,
     })
   } catch (error: unknown) {

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -34,7 +34,6 @@ onMessage("mina_switchChain", minaSwitchChain)
 onMessage("mina_getState", minaGetState)
 onMessage("mina_chainId", minaChainId)
 onMessage("mina_accounts", minaAccounts)
-// TODO: It should be removed, but let's keep it for now for Auro compatibility.
 onMessage("mina_requestAccounts", minaRequestAccounts)
 onMessage("mina_sign", minaSign)
 onMessage("mina_signFields", minaSignFields)

--- a/packages/web-provider/src/mina-network/constants/rpc.ts
+++ b/packages/web-provider/src/mina-network/constants/rpc.ts
@@ -1,7 +1,7 @@
 export const REQUIRED_METHODS = ["mina_sendTransaction"]
 export const OPTIONAL_METHODS = [
   "mina_accounts",
-  "mina_requestAccounts", // this is a legacy method, could be removed
+  "mina_requestAccounts",
   "mina_sign",
   "mina_signTransaction",
   "mina_signFields",


### PR DESCRIPTION
This PR is made to add mina_requestAccounts provider method and return an empty array in response to mina_accounts if the wallet is not connected.

I tried to make minimum changes to the code, but it's better if this is managed by a complete permission system in the wallet
